### PR TITLE
Add retry attempts

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -23,6 +23,7 @@ func serviceCmd(ctx *config.Context) *cobra.Command {
 func startCmd(ctx *config.Context) *cobra.Command {
 	const (
 		flagRelayInterval = "relay-interval"
+		flagRelayAttempts = "relay-attempts"
 	)
 
 	cmd := &cobra.Command{
@@ -41,9 +42,10 @@ func startCmd(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return core.StartService(context.Background(), st, c[src], c[dst], viper.GetDuration(flagRelayInterval))
+			return core.StartService(context.Background(), st, c[src], c[dst], viper.GetDuration(flagRelayInterval), viper.GetUint(flagRelayAttempts))
 		},
 	}
 	cmd.Flags().Duration(flagRelayInterval, 3*time.Second, "time interval to perform relays")
+	cmd.Flags().Uint(flagRelayAttempts, 5, "count of retry")
 	return cmd
 }


### PR DESCRIPTION
Add attempts flag for `uly service start` cmd and retry interval depend on not fixed value but interval flag.
This changes will increase availability of Relayer service

Signed-off-by: Koji Matsumiya <koji.matsumiya@datachain.jp>