### PR TITLE
Add path config edit command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -23,6 +22,7 @@ func configCmd(ctx *config.Context) *cobra.Command {
 	cmd.AddCommand(
 		configShowCmd(ctx),
 		configInitCmd(),
+		configEditCmd(ctx),
 	)
 
 	return cmd
@@ -116,6 +116,62 @@ func configShowCmd(ctx *config.Context) *cobra.Command {
 	return cmd
 }
 
+func configEditCmd(ctx *config.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "edit [path-name] [key] [value]",
+		Aliases: []string{"e"},
+		Short:   "Edit the config file",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			home, err := cmd.Flags().GetString(flags.FlagHome)
+			if err != nil {
+				return err
+			}
+			cfgPath := path.Join(home, "config", "config.yaml")
+			if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
+				if _, err := os.Stat(home); os.IsNotExist(err) {
+					return fmt.Errorf("home path does not exist: %s", home)
+				}
+				return fmt.Errorf("config does not exist: %s", cfgPath)
+			}
+			pathName := args[0]
+			key := args[1]
+			value := args[2]
+			configPath, err := ctx.Config.Paths.Get(pathName)
+			if err != nil {
+				return err
+			}
+			switch key {
+			case "client-id":
+				configPath.Src.ClientID = value
+				configPath.Dst.ClientID = value
+			case "channel-id":
+				configPath.Src.ChannelID = value
+				configPath.Dst.ChannelID = value
+			case "connection-id":
+				configPath.Src.ConnectionID = value
+				configPath.Dst.ConnectionID = value
+			case "port-id":
+				configPath.Src.PortID = value
+				configPath.Dst.PortID = value
+			default:
+				return fmt.Errorf("invalid key: %s. Valid keys are: client-id, channel-id, connection-id, port-id", key)
+			}
+			ctx.Config.Paths[pathName] = configPath
+			out, err := config.MarshalJSON(*ctx.Config)
+			if err != nil {
+				return err
+			}
+			err = os.WriteFile(cfgPath, out, 0600)
+			if err != nil {
+				return err
+			}
+			fmt.Println("config file updated")
+			return nil
+		},
+	}
+	return cmd
+}
+
 func defaultConfig() []byte {
 	bz, err := json.Marshal(config.DefaultConfig())
 	if err != nil {
@@ -136,7 +192,7 @@ func initConfig(ctx *config.Context, cmd *cobra.Command) error {
 		viper.SetConfigFile(cfgPath)
 		if err := viper.ReadInConfig(); err == nil {
 			// read the config file bytes
-			file, err := ioutil.ReadFile(viper.ConfigFileUsed())
+			file, err := os.ReadFile(viper.ConfigFileUsed())
 			if err != nil {
 				fmt.Println("Error reading file:", err)
 				os.Exit(1)


### PR DESCRIPTION
Add edit command to config commands
```
$RELAY config edit $PATH_NAME [key] [value]
```
example
```
$RELAY config edit $PATH_NAME client-id clinet-abc
$RELAY config edit $PATH_NAME channel-id channel-abc
$RELAY config edit $PATH_NAME connection-id connection-abc
$RELAY config edit $PATH_NAME port-id port-abc
```
