### PR TITLE
Add check process for channel and connection finalization to handshake

### DIFF
--- a/core/channel.go
+++ b/core/channel.go
@@ -28,6 +28,10 @@ func CreateChannel(src, dst *ProvableChain, ordered bool, to time.Duration) erro
 			return err
 		}
 
+		if !chanSteps.Ready() {
+			continue
+		}
+
 		chanSteps.Send(src, dst)
 
 		switch {

--- a/core/channel.go
+++ b/core/channel.go
@@ -29,6 +29,7 @@ func CreateChannel(src, dst *ProvableChain, ordered bool, to time.Duration) erro
 		}
 
 		if !chanSteps.Ready() {
+			log.Println("Waiting for next channel step ...")
 			continue
 		}
 
@@ -197,9 +198,11 @@ func checkChannelFinality(src, dst *ProvableChain, srcChannel, dstChannel *chant
 		return false, err
 	}
 	if srcChannel.State != srcChanLatest.Channel.State {
+		log.Printf("Source Channel: Finalized state [%s] <> Latest state [%s]", srcChannel.State, srcChanLatest.Channel.State)
 		return false, nil
 	}
 	if dstChannel.State != dstChanLatest.Channel.State {
+		log.Printf("Destination Channel: Finalized state [%s] <> Latest state [%s]", dstChannel.State, dstChanLatest.Channel.State)
 		return false, nil
 	}
 	return true, nil

--- a/core/connection.go
+++ b/core/connection.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -27,10 +28,6 @@ func CreateConnection(src, dst *ProvableChain, to time.Duration) error {
 		connSteps, err := createConnectionStep(src, dst)
 		if err != nil {
 			return err
-		}
-
-		if !connSteps.Ready() {
-			break
 		}
 
 		connSteps.Send(src, dst)
@@ -98,6 +95,12 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 	srcConn, dstConn, err := QueryConnectionPair(sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()), src, dst)
 	if err != nil {
 		return nil, err
+	}
+
+	if finalized, err := checkConnectionFinality(src, dst, srcConn.Connection, dstConn.Connection); err != nil {
+		return nil, err
+	} else if !finalized {
+		return out, nil
 	}
 
 	if !(srcConn.Connection.State == conntypes.UNINITIALIZED && dstConn.Connection.State == conntypes.UNINITIALIZED) {
@@ -235,4 +238,26 @@ func mustGetAddress(chain interface {
 		panic(err)
 	}
 	return addr
+}
+
+func checkConnectionFinality(src, dst *ProvableChain, srcConnection, dstConnection *conntypes.ConnectionEnd) (bool, error) {
+	sh, err := src.LatestHeight()
+	if err != nil {
+		return false, err
+	}
+	dh, err := dst.LatestHeight()
+	if err != nil {
+		return false, err
+	}
+	srcConnLatest, dstConnLatest, err := QueryConnectionPair(NewQueryContext(context.TODO(), sh), NewQueryContext(context.TODO(), dh), src, dst)
+	if err != nil {
+		return false, err
+	}
+	if srcConnection.State != srcConnLatest.Connection.State {
+		return false, nil
+	}
+	if dstConnection.State != dstConnLatest.Connection.State {
+		return false, nil
+	}
+	return true, nil
 }

--- a/core/connection.go
+++ b/core/connection.go
@@ -31,6 +31,7 @@ func CreateConnection(src, dst *ProvableChain, to time.Duration) error {
 		}
 
 		if !connSteps.Ready() {
+			log.Println("Waiting for next connection step ...")
 			continue
 		}
 
@@ -258,9 +259,11 @@ func checkConnectionFinality(src, dst *ProvableChain, srcConnection, dstConnecti
 		return false, err
 	}
 	if srcConnection.State != srcConnLatest.Connection.State {
+		log.Printf("Source Connection: Finalized state [%s] <> Latest state [%s]", srcConnection.State, srcConnLatest.Connection.State)
 		return false, nil
 	}
 	if dstConnection.State != dstConnLatest.Connection.State {
+		log.Printf("Destination Connection: Finalized state [%s] <> Latest state [%s]", dstConnection.State, dstConnLatest.Connection.State)
 		return false, nil
 	}
 	return true, nil

--- a/core/connection.go
+++ b/core/connection.go
@@ -30,6 +30,10 @@ func CreateConnection(src, dst *ProvableChain, to time.Duration) error {
 			return err
 		}
 
+		if !connSteps.Ready() {
+			continue
+		}
+
 		connSteps.Send(src, dst)
 
 		switch {


### PR DESCRIPTION
* set `finality_delay` value to 5
* `connection not finalized, retrying...` is debug log

```
sts/eth2eth/scripts/../demo/.urelayer tx connection ibc01
2023/08/30 11:49:13 - [ibc0]@{0}conn(connection-0)-{STATE_UNINITIALIZED_UNSPECIFIED} : [ibc1]@{0}conn(connection-0)-{STATE_UNINITIALIZED_UNSPECIFIED}
2023/08/30 11:49:19 connection not finalized, retrying...
2023/08/30 11:49:20 connection not finalized, retrying...
2023/08/30 11:49:21 connection not finalized, retrying...
2023/08/30 11:49:22 connection not finalized, retrying...
2023/08/30 11:49:23 - [ibc1]@{0}conn(connection-0)-{STATE_UNINITIALIZED_UNSPECIFIED} : [ibc0]@{240}conn(connection-0)-{STATE_INIT}
2023/08/30 11:49:29 connection not finalized, retrying...
2023/08/30 11:49:30 connection not finalized, retrying...
2023/08/30 11:49:31 connection not finalized, retrying...
2023/08/30 11:49:32 connection not finalized, retrying...
2023/08/30 11:49:33 - [ibc0]@{250}conn(connection-0)-{STATE_INIT} : [ibc1]@{250}conn(connection-0)-{STATE_TRYOPEN}
2023/08/30 11:49:39 connection not finalized, retrying...
2023/08/30 11:49:40 connection not finalized, retrying...
2023/08/30 11:49:41 connection not finalized, retrying...
2023/08/30 11:49:42 connection not finalized, retrying...
2023/08/30 11:49:43 - [ibc1]@{260}conn(connection-0)-{STATE_TRYOPEN} : [ibc0]@{260}conn(connection-0)-{STATE_OPEN}
2023/08/30 11:49:49 ★ Connection created: [ibc0]client{mock-client-0}conn{connection-0} -> [ibc1]client{mock-client-0}conn{connection-0}
+ /Users/dongri.jin/go/src/github.com/datachainlab/toki-relayer-longrun/tests/eth2eth/scripts/../../../relayer/build/relayer --home /Users/dongri.jin/go/src/github.com/datachainlab/toki-relayer-longrun/tests/eth2eth/scripts/../demo/.urelayer tx channel ibc01
2023/08/30 11:49:49 - [ibc0]@{0}chan(channel-0)-{STATE_UNINITIALIZED_UNSPECIFIED} : [ibc1]@{0}chan(channel-0)-{STATE_UNINITIALIZED_UNSPECIFIED}
2023/08/30 11:49:53 channel not finalized, retrying...
2023/08/30 11:49:53 channel not finalized, retrying...
2023/08/30 11:49:54 channel not finalized, retrying...
2023/08/30 11:49:55 channel not finalized, retrying...
2023/08/30 11:49:56 - [ibc1]@{0}chan(channel-0)-{STATE_UNINITIALIZED_UNSPECIFIED} : [ibc0]@{273}chan(channel-0)-{STATE_INIT}
2023/08/30 11:50:03 channel not finalized, retrying...
2023/08/30 11:50:03 channel not finalized, retrying...
2023/08/30 11:50:04 channel not finalized, retrying...
2023/08/30 11:50:05 channel not finalized, retrying...
2023/08/30 11:50:06 - [ibc0]@{283}chan(channel-0)-{STATE_INIT} : [ibc1]@{283}chan(channel-0)-{STATE_TRYOPEN}
2023/08/30 11:50:13 channel not finalized, retrying...
2023/08/30 11:50:13 channel not finalized, retrying...
2023/08/30 11:50:14 channel not finalized, retrying...
2023/08/30 11:50:15 channel not finalized, retrying...
2023/08/30 11:50:16 - [ibc1]@{293}chan(channel-0)-{STATE_TRYOPEN} : [ibc0]@{293}chan(channel-0)-{STATE_OPEN}
2023/08/30 11:50:23 ★ Channel created: [ibc0]chan{channel-0}port{transfer} -> [ibc1]chan{channel-0}port{transfer}
+ set +x
```
