### PR TITLE
Add time track

### DIFF
--- a/core/channel.go
+++ b/core/channel.go
@@ -15,6 +15,7 @@ import (
 // TODO: add max retries or something to this function
 func CreateChannel(src, dst *ProvableChain, ordered bool, to time.Duration) error {
 	logger := GetChannelPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "CreateChannel")
 	var order chantypes.Order
 	if ordered {
 		order = chantypes.ORDERED

--- a/core/client.go
+++ b/core/client.go
@@ -1,6 +1,8 @@
 package core
 
 import (
+	"time"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/hyperledger-labs/yui-relayer/log"
 	"golang.org/x/sync/errgroup"
@@ -8,6 +10,7 @@ import (
 
 func CreateClients(src, dst *ProvableChain) error {
 	logger := GetChainPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "CreateClients")
 	var (
 		clients = &RelayMsgs{Src: []sdk.Msg{}, Dst: []sdk.Msg{}}
 	)
@@ -76,6 +79,7 @@ func CreateClients(src, dst *ProvableChain) error {
 
 func UpdateClients(src, dst *ProvableChain) error {
 	logger := GetClientPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "UpdateClients")
 	var (
 		clients = &RelayMsgs{Src: []sdk.Msg{}, Dst: []sdk.Msg{}}
 	)

--- a/core/connection.go
+++ b/core/connection.go
@@ -24,6 +24,7 @@ var (
 
 func CreateConnection(src, dst *ProvableChain, to time.Duration) error {
 	logger := GetConnectionPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "CreateConnection")
 	ticker := time.NewTicker(to)
 
 	failed := 0

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"time"
 
 	retry "github.com/avast/retry-go"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -72,6 +73,7 @@ func getQueryContext(chain *ProvableChain, sh SyncHeaders, useFinalizedHeader bo
 
 func (st *NaiveStrategy) UnrelayedPackets(src, dst *ProvableChain, sh SyncHeaders, includeRelayedButUnfinalized bool) (*RelayPackets, error) {
 	logger := GetChannelPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "UnrelayedPackets")
 	var (
 		eg         = new(errgroup.Group)
 		srcPackets PacketInfoList
@@ -177,6 +179,7 @@ func (st *NaiveStrategy) UnrelayedPackets(src, dst *ProvableChain, sh SyncHeader
 
 func (st *NaiveStrategy) RelayPackets(src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders) error {
 	logger := GetChannelPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "RelayPackets")
 	// set the maximum relay transaction constraints
 	msgs := &RelayMsgs{
 		Src:          []sdk.Msg{},
@@ -275,6 +278,7 @@ func (st *NaiveStrategy) RelayPackets(src, dst *ProvableChain, rp *RelayPackets,
 
 func (st *NaiveStrategy) UnrelayedAcknowledgements(src, dst *ProvableChain, sh SyncHeaders, includeRelayedButUnfinalized bool) (*RelayPackets, error) {
 	logger := GetChannelPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "UnrelayedAcknowledgements")
 	var (
 		eg      = new(errgroup.Group)
 		srcAcks PacketInfoList
@@ -417,6 +421,7 @@ func logPacketsRelayed(src, dst Chain, num int, obj string, dir string) {
 
 func (st *NaiveStrategy) RelayAcknowledgements(src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders) error {
 	logger := GetChannelPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "RelayAcknowledgements")
 	// set the maximum relay transaction constraints
 	msgs := &RelayMsgs{
 		Src:          []sdk.Msg{},

--- a/core/packet-tx.go
+++ b/core/packet-tx.go
@@ -9,6 +9,7 @@ import (
 
 func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr fmt.Stringer, toHeightOffset uint64, toTimeOffset time.Duration) error {
 	logger := GetChannelPairLogger(src, dst)
+	defer logger.TimeTrack(time.Now(), "SendTransferMsg")
 	var (
 		timeoutHeight    uint64
 		timeoutTimestamp uint64

--- a/log/slog.go
+++ b/log/slog.go
@@ -81,6 +81,16 @@ func GetLogger() *RelayLogger {
 	return relayLogger
 }
 
+func (rl *RelayLogger) WithChain(
+	chainID string,
+) *RelayLogger {
+	return &RelayLogger{
+		rl.Logger.With(
+			"chain_id", chainID,
+		),
+	}
+}
+
 func (rl *RelayLogger) WithChainPair(
 	srcChainID string,
 	dstChainID string,

--- a/log/slog.go
+++ b/log/slog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/withstack"
@@ -174,4 +175,9 @@ func (rl *RelayLogger) WithModule(
 			"module", moduleName,
 		),
 	}
+}
+
+func (rl *RelayLogger) TimeTrack(start time.Time, name string) {
+	elapsed := time.Since(start)
+	rl.Logger.Info("time track", "name", name, "elapsed", elapsed.Nanoseconds())
 }


### PR DESCRIPTION
Add time track
```
{"time":"2023-09-14T10:25:00.919158+09:00","level":"INFO","source":{"function":"github.com/hyperledger-labs/yui-relayer/log.(*RelayLogger).TimeTrack","file":"/Users/dongri.jin/go/src/github.com/dongrie/yui-relayer-time-track/log/slog.go","line":182},"msg":"time track","module":"ethereum.chain","name":"findRecvPacketEvents","elapsed":10582031}
{"time":"2023-09-14T10:25:00.921196+09:00","level":"INFO","source":{"function":"github.com/hyperledger-labs/yui-relayer/log.(*RelayLogger).TimeTrack","file":"/Users/dongri.jin/go/src/github.com/dongrie/yui-relayer-time-track/log/slog.go","line":182},"msg":"time track","module":"ethereum.chain","name":"findRecvPacketEvents","elapsed":12625927}

{"time":"2023-09-14T10:25:00.934499+09:00","level":"INFO","source":{"function":"github.com/hyperledger-labs/yui-relayer/log.(*RelayLogger).TimeTrack","file":"/Users/dongri.jin/go/src/github.com/dongrie/yui-relayer-time-track/log/slog.go","line":182},"msg":"time track","module":"ethereum.chain","name":"QueryUnreceivedAcknowledgements","elapsed":356}
{"time":"2023-09-14T10:25:00.936148+09:00","level":"INFO","source":{"function":"github.com/hyperledger-labs/yui-relayer/log.(*RelayLogger).TimeTrack","file":"/Users/dongri.jin/go/src/github.com/dongrie/yui-relayer-time-track/log/slog.go","line":182},"msg":"time track","module":"ethereum.chain","name":"QueryUnfinalizedRelayAcknowledgements","elapsed":27791926}
{"time":"2023-09-14T10:25:00.941646+09:00","level":"INFO","source":{"function":"github.com/hyperledger-labs/yui-relayer/log.(*RelayLogger).TimeTrack","file":"/Users/dongri.jin/go/src/github.com/dongrie/yui-relayer-time-track/log/slog.go","line":182},"msg":"time track","module":"ethereum.chain","name":"QueryUnreceivedAcknowledgements","elapsed":3310680}
```
