### PR TITLE
Fix to do not generate a proof in the finality check

### DIFF
--- a/core/channel.go
+++ b/core/channel.go
@@ -104,7 +104,7 @@ func createChannelStep(src, dst *ProvableChain, ordering chantypes.Order) (*Rela
 		return nil, err
 	}
 
-	srcChan, dstChan, err := QueryChannelPair(sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()), src, dst)
+	srcChan, dstChan, err := QueryChannelPair(sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()), src, dst, true)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +207,7 @@ func checkChannelFinality(src, dst *ProvableChain, srcChannel, dstChannel *chant
 	if err != nil {
 		return false, err
 	}
-	srcChanLatest, dstChanLatest, err := QueryChannelPair(NewQueryContext(context.TODO(), sh), NewQueryContext(context.TODO(), dh), src, dst)
+	srcChanLatest, dstChanLatest, err := QueryChannelPair(NewQueryContext(context.TODO(), sh), NewQueryContext(context.TODO(), dh), src, dst, false)
 	if err != nil {
 		return false, err
 	}

--- a/core/connection.go
+++ b/core/connection.go
@@ -110,7 +110,7 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		return nil, err
 	}
 
-	srcConn, dstConn, err := QueryConnectionPair(sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()), src, dst)
+	srcConn, dstConn, err := QueryConnectionPair(sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()), src, dst, true)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 
 	if !(srcConn.Connection.State == conntypes.UNINITIALIZED && dstConn.Connection.State == conntypes.UNINITIALIZED) {
 		// Query client state from each chain's client
-		srcCsRes, dstCsRes, err = QueryClientStatePair(sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()), src, dst)
+		srcCsRes, dstCsRes, err = QueryClientStatePair(sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()), src, dst, true)
 		if err != nil && (srcCsRes == nil || dstCsRes == nil) {
 			return nil, err
 		}
@@ -138,7 +138,7 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		srcConsH, dstConsH = srcCS.GetLatestHeight(), dstCS.GetLatestHeight()
 		srcCons, dstCons, err = QueryClientConsensusStatePair(
 			sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()),
-			src, dst, srcConsH, dstConsH)
+			src, dst, srcConsH, dstConsH, true)
 		if err != nil {
 			return nil, err
 		}
@@ -269,7 +269,7 @@ func checkConnectionFinality(src, dst *ProvableChain, srcConnection, dstConnecti
 	if err != nil {
 		return false, err
 	}
-	srcConnLatest, dstConnLatest, err := QueryConnectionPair(NewQueryContext(context.TODO(), sh), NewQueryContext(context.TODO(), dh), src, dst)
+	srcConnLatest, dstConnLatest, err := QueryConnectionPair(NewQueryContext(context.TODO(), sh), NewQueryContext(context.TODO(), dh), src, dst, false)
 	if err != nil {
 		return false, err
 	}

--- a/core/query.go
+++ b/core/query.go
@@ -16,6 +16,7 @@ func QueryClientStatePair(
 		Chain
 		StateProver
 	},
+	prove bool,
 ) (srcCsRes, dstCsRes *clienttypes.QueryClientStateResponse, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
@@ -27,8 +28,10 @@ func QueryClientStatePair(
 		if err != nil {
 			return err
 		}
-		path := host.FullClientStatePath(src.Path().ClientID)
-		srcCsRes.Proof, srcCsRes.ProofHeight, err = src.ProveState(srcCtx, path, value)
+		if prove {
+			path := host.FullClientStatePath(src.Path().ClientID)
+			srcCsRes.Proof, srcCsRes.ProofHeight, err = src.ProveState(srcCtx, path, value)
+		}
 		return err
 	})
 	eg.Go(func() error {
@@ -40,8 +43,10 @@ func QueryClientStatePair(
 		if err != nil {
 			return err
 		}
-		path := host.FullClientStatePath(dst.Path().ClientID)
-		dstCsRes.Proof, dstCsRes.ProofHeight, err = dst.ProveState(dstCtx, path, value)
+		if prove {
+			path := host.FullClientStatePath(dst.Path().ClientID)
+			dstCsRes.Proof, dstCsRes.ProofHeight, err = dst.ProveState(dstCtx, path, value)
+		}
 		return err
 	})
 	err = eg.Wait()
@@ -56,7 +61,9 @@ func QueryClientConsensusStatePair(
 		StateProver
 	},
 	srcClientConsH,
-	dstClientConsH ibcexported.Height) (srcCsRes, dstCsRes *clienttypes.QueryConsensusStateResponse, err error) {
+	dstClientConsH ibcexported.Height,
+	prove bool,
+) (srcCsRes, dstCsRes *clienttypes.QueryConsensusStateResponse, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
 		srcCsRes, err = src.QueryClientConsensusState(srcCtx, srcClientConsH)
@@ -67,8 +74,10 @@ func QueryClientConsensusStatePair(
 		if err != nil {
 			return err
 		}
-		path := host.FullConsensusStatePath(src.Path().ClientID, srcClientConsH)
-		srcCsRes.Proof, srcCsRes.ProofHeight, err = src.ProveState(srcCtx, path, value)
+		if prove {
+			path := host.FullConsensusStatePath(src.Path().ClientID, srcClientConsH)
+			srcCsRes.Proof, srcCsRes.ProofHeight, err = src.ProveState(srcCtx, path, value)
+		}
 		return err
 	})
 	eg.Go(func() error {
@@ -80,8 +89,10 @@ func QueryClientConsensusStatePair(
 		if err != nil {
 			return err
 		}
-		path := host.FullConsensusStatePath(dst.Path().ClientID, dstClientConsH)
-		dstCsRes.Proof, dstCsRes.ProofHeight, err = dst.ProveState(dstCtx, path, value)
+		if prove {
+			path := host.FullConsensusStatePath(dst.Path().ClientID, dstClientConsH)
+			dstCsRes.Proof, dstCsRes.ProofHeight, err = dst.ProveState(dstCtx, path, value)
+		}
 		return err
 	})
 	err = eg.Wait()
@@ -95,6 +106,7 @@ func QueryConnectionPair(
 		Chain
 		StateProver
 	},
+	prove bool,
 ) (srcConn, dstConn *conntypes.QueryConnectionResponse, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
@@ -108,8 +120,10 @@ func QueryConnectionPair(
 		if err != nil {
 			return err
 		}
-		path := host.ConnectionPath(src.Path().ConnectionID)
-		srcConn.Proof, srcConn.ProofHeight, err = src.ProveState(srcCtx, path, value)
+		if prove {
+			path := host.ConnectionPath(src.Path().ConnectionID)
+			srcConn.Proof, srcConn.ProofHeight, err = src.ProveState(srcCtx, path, value)
+		}
 		return err
 	})
 	eg.Go(func() error {
@@ -123,8 +137,10 @@ func QueryConnectionPair(
 		if err != nil {
 			return err
 		}
-		path := host.ConnectionPath(dst.Path().ConnectionID)
-		dstConn.Proof, dstConn.ProofHeight, err = dst.ProveState(dstCtx, path, value)
+		if prove {
+			path := host.ConnectionPath(dst.Path().ConnectionID)
+			dstConn.Proof, dstConn.ProofHeight, err = dst.ProveState(dstCtx, path, value)
+		}
 		return err
 	})
 	err = eg.Wait()
@@ -135,7 +151,7 @@ func QueryConnectionPair(
 func QueryChannelPair(srcCtx, dstCtx QueryContext, src, dst interface {
 	Chain
 	StateProver
-}) (srcChan, dstChan *chantypes.QueryChannelResponse, err error) {
+}, prove bool) (srcChan, dstChan *chantypes.QueryChannelResponse, err error) {
 	var eg = new(errgroup.Group)
 	eg.Go(func() error {
 		srcChan, err = src.QueryChannel(srcCtx)
@@ -148,8 +164,10 @@ func QueryChannelPair(srcCtx, dstCtx QueryContext, src, dst interface {
 		if err != nil {
 			return err
 		}
-		path := host.ChannelPath(src.Path().PortID, src.Path().ChannelID)
-		srcChan.Proof, srcChan.ProofHeight, err = src.ProveState(srcCtx, path, value)
+		if prove {
+			path := host.ChannelPath(src.Path().PortID, src.Path().ChannelID)
+			srcChan.Proof, srcChan.ProofHeight, err = src.ProveState(srcCtx, path, value)
+		}
 		return err
 	})
 	eg.Go(func() error {
@@ -163,8 +181,10 @@ func QueryChannelPair(srcCtx, dstCtx QueryContext, src, dst interface {
 		if err != nil {
 			return err
 		}
-		path := host.ChannelPath(dst.Path().PortID, dst.Path().ChannelID)
-		dstChan.Proof, dstChan.ProofHeight, err = dst.ProveState(dstCtx, path, value)
+		if prove {
+			path := host.ChannelPath(dst.Path().PortID, dst.Path().ChannelID)
+			dstChan.Proof, dstChan.ProofHeight, err = dst.ProveState(dstCtx, path, value)
+		}
 		return err
 	})
 	err = eg.Wait()

--- a/core/query.go
+++ b/core/query.go
@@ -24,12 +24,12 @@ func QueryClientStatePair(
 		if err != nil {
 			return err
 		}
-		value, err := src.Codec().Marshal(srcCsRes.ClientState)
-		if err != nil {
-			return err
-		}
 		if prove {
 			path := host.FullClientStatePath(src.Path().ClientID)
+			value, err := src.Codec().Marshal(srcCsRes.ClientState)
+			if err != nil {
+				return err
+			}
 			srcCsRes.Proof, srcCsRes.ProofHeight, err = src.ProveState(srcCtx, path, value)
 		}
 		return err
@@ -39,12 +39,12 @@ func QueryClientStatePair(
 		if err != nil {
 			return err
 		}
-		value, err := dst.Codec().Marshal(dstCsRes.ClientState)
-		if err != nil {
-			return err
-		}
 		if prove {
 			path := host.FullClientStatePath(dst.Path().ClientID)
+			value, err := dst.Codec().Marshal(dstCsRes.ClientState)
+			if err != nil {
+				return err
+			}
 			dstCsRes.Proof, dstCsRes.ProofHeight, err = dst.ProveState(dstCtx, path, value)
 		}
 		return err
@@ -70,12 +70,12 @@ func QueryClientConsensusStatePair(
 		if err != nil {
 			return err
 		}
-		value, err := src.Codec().Marshal(srcCsRes.ConsensusState)
-		if err != nil {
-			return err
-		}
 		if prove {
 			path := host.FullConsensusStatePath(src.Path().ClientID, srcClientConsH)
+			value, err := src.Codec().Marshal(srcCsRes.ConsensusState)
+			if err != nil {
+				return err
+			}
 			srcCsRes.Proof, srcCsRes.ProofHeight, err = src.ProveState(srcCtx, path, value)
 		}
 		return err
@@ -85,12 +85,12 @@ func QueryClientConsensusStatePair(
 		if err != nil {
 			return err
 		}
-		value, err := dst.Codec().Marshal(dstCsRes.ConsensusState)
-		if err != nil {
-			return err
-		}
 		if prove {
 			path := host.FullConsensusStatePath(dst.Path().ClientID, dstClientConsH)
+			value, err := dst.Codec().Marshal(dstCsRes.ConsensusState)
+			if err != nil {
+				return err
+			}
 			dstCsRes.Proof, dstCsRes.ProofHeight, err = dst.ProveState(dstCtx, path, value)
 		}
 		return err
@@ -116,12 +116,12 @@ func QueryConnectionPair(
 		} else if srcConn.Connection.State == conntypes.UNINITIALIZED {
 			return nil
 		}
-		value, err := src.Codec().Marshal(srcConn.Connection)
-		if err != nil {
-			return err
-		}
 		if prove {
 			path := host.ConnectionPath(src.Path().ConnectionID)
+			value, err := src.Codec().Marshal(srcConn.Connection)
+			if err != nil {
+				return err
+			}
 			srcConn.Proof, srcConn.ProofHeight, err = src.ProveState(srcCtx, path, value)
 		}
 		return err
@@ -133,12 +133,12 @@ func QueryConnectionPair(
 		} else if dstConn.Connection.State == conntypes.UNINITIALIZED {
 			return nil
 		}
-		value, err := dst.Codec().Marshal(dstConn.Connection)
-		if err != nil {
-			return err
-		}
 		if prove {
 			path := host.ConnectionPath(dst.Path().ConnectionID)
+			value, err := dst.Codec().Marshal(dstConn.Connection)
+			if err != nil {
+				return err
+			}
 			dstConn.Proof, dstConn.ProofHeight, err = dst.ProveState(dstCtx, path, value)
 		}
 		return err
@@ -160,12 +160,12 @@ func QueryChannelPair(srcCtx, dstCtx QueryContext, src, dst interface {
 		} else if srcChan.Channel.State == chantypes.UNINITIALIZED {
 			return nil
 		}
-		value, err := src.Codec().Marshal(srcChan.Channel)
-		if err != nil {
-			return err
-		}
 		if prove {
 			path := host.ChannelPath(src.Path().PortID, src.Path().ChannelID)
+			value, err := src.Codec().Marshal(srcChan.Channel)
+			if err != nil {
+				return err
+			}
 			srcChan.Proof, srcChan.ProofHeight, err = src.ProveState(srcCtx, path, value)
 		}
 		return err
@@ -177,12 +177,12 @@ func QueryChannelPair(srcCtx, dstCtx QueryContext, src, dst interface {
 		} else if dstChan.Channel.State == chantypes.UNINITIALIZED {
 			return nil
 		}
-		value, err := dst.Codec().Marshal(dstChan.Channel)
-		if err != nil {
-			return err
-		}
 		if prove {
 			path := host.ChannelPath(dst.Path().PortID, dst.Path().ChannelID)
+			value, err := dst.Codec().Marshal(dstChan.Channel)
+			if err != nil {
+				return err
+			}
 			dstChan.Proof, dstChan.ProofHeight, err = dst.ProveState(dstCtx, path, value)
 		}
 		return err


### PR DESCRIPTION
Proof generation is not required for querying states in the finality check. This also reduces composability when proxied by other verifier such as lcp.