### PR TITLE
ICS-20: Remove bech32 check for `dstAddr`

### DIFF
--- a/cmd/xfer.go
+++ b/cmd/xfer.go
@@ -58,11 +58,7 @@ func xfersend(ctx *config.Context) *cobra.Command {
 			if denom.Path != "" {
 				amount.Denom = denom.IBCDenom()
 			}
-
-			dstAddr, err := sdk.AccAddressFromBech32(args[4])
-			if err != nil {
-				return err
-			}
+			dstAddr := args[4]
 
 			switch {
 			case toHeightOffset > 0 && toTimeOffset > 0:

--- a/core/packet-tx.go
+++ b/core/packet-tx.go
@@ -7,7 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr fmt.Stringer, toHeightOffset uint64, toTimeOffset time.Duration) error {
+func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration) error {
 	logger := GetChannelPairLogger(src, dst)
 	defer logger.TimeTrack(time.Now(), "SendTransferMsg")
 	var (
@@ -19,9 +19,6 @@ func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr fmt.Strin
 	if err != nil {
 		return err
 	}
-
-	// Properly render the address string
-	dstAddrString := dstAddr.String()
 
 	switch {
 	case toHeightOffset > 0 && toTimeOffset > 0:
@@ -49,7 +46,7 @@ func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr fmt.Strin
 	// MsgTransfer will call SendPacket on src chain
 	txs := RelayMsgs{
 		Src: []sdk.Msg{src.Path().MsgTransfer(
-			dst.Path(), amount, dstAddrString, srcAddr, timeoutHeight, timeoutTimestamp, "",
+			dst.Path(), amount, dstAddr, srcAddr, timeoutHeight, timeoutTimestamp, "",
 		)},
 		Dst: []sdk.Msg{},
 	}


### PR DESCRIPTION
This allows us to specify arbitrary string format including ethereum "0x" prefixed address as `dstAddr`.