### PR TITLE
reorganize interfaces that makes up the Prover interface

### DIFF
--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -82,7 +82,7 @@ func (pr *Prover) SetupHeadersForUpdate(counterparty core.FinalityAwareChain, la
 		return nil, err
 	}
 
-	// retrieve counterparty client from dst chain
+	// retrieve the client state from the counterparty chain
 	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(context.TODO(), cph))
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func (pr *Prover) SetupHeadersForUpdate(counterparty core.FinalityAwareChain, la
 	// inject TrustedHeight as latest height stored on counterparty client
 	h.TrustedHeight = cs.GetLatestHeight().(clienttypes.Height)
 
-	// query TrustedValidators at Trusted Height from srcChain
+	// query TrustedValidators at Trusted Height from the self chain
 	valSet, err := self.QueryValsetAtHeight(h.TrustedHeight)
 	if err != nil {
 		return nil, err

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -56,14 +56,14 @@ func (pr *Prover) ProveState(ctx core.QueryContext, path string, value []byte) (
 
 /* LightClient implementation */
 
-// CreateMsgCreateClient creates a CreateClientMsg to this chain
-func (pr *Prover) CreateMsgCreateClient(clientID string, dstHeader core.Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error) {
+// CreateMsgCreateClient creates a MsgCreateClient for the counterparty chain
+func (pr *Prover) CreateMsgCreateClient(clientID string, selfHeader core.Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error) {
 	ubdPeriod, err := pr.chain.QueryUnbondingPeriod()
 	if err != nil {
 		return nil, err
 	}
 	return createClient(
-		dstHeader.(*tmclient.Header),
+		selfHeader.(*tmclient.Header),
 		pr.getTrustingPeriod(),
 		ubdPeriod,
 		signer,

--- a/core/headers.go
+++ b/core/headers.go
@@ -27,10 +27,10 @@ type SyncHeaders interface {
 	GetQueryContext(chainID string) QueryContext
 
 	// SetupHeadersForUpdate returns `src` chain's headers needed to update the client on `dst` chain
-	SetupHeadersForUpdate(src, dst ChainICS02QuerierLightClient) ([]Header, error)
+	SetupHeadersForUpdate(src, dst ChainLightClient) ([]Header, error)
 
 	// SetupBothHeadersForUpdate returns both `src` and `dst` chain's headers needed to update the clients on each chain
-	SetupBothHeadersForUpdate(src, dst ChainICS02QuerierLightClient) (srcHeaders []Header, dstHeaders []Header, err error)
+	SetupBothHeadersForUpdate(src, dst ChainLightClient) (srcHeaders []Header, dstHeaders []Header, err error)
 }
 
 // ChainInfoLightClient = ChainInfo + LightClient
@@ -39,10 +39,10 @@ type ChainInfoLightClient interface {
 	LightClient
 }
 
-// ChainICS02QuerierLightClient = ChainInfoLightClient + ICS02Querier
-type ChainICS02QuerierLightClient interface {
-	ChainInfoLightClient
-	ICS02Querier
+// ChainLightClient = Chain + LightClient
+type ChainLightClient interface {
+	Chain
+	LightClient
 }
 
 type syncHeaders struct {
@@ -122,7 +122,7 @@ func (sh syncHeaders) GetQueryContext(chainID string) QueryContext {
 }
 
 // SetupHeadersForUpdate returns `src` chain's headers to update the client on `dst` chain
-func (sh syncHeaders) SetupHeadersForUpdate(src, dst ChainICS02QuerierLightClient) ([]Header, error) {
+func (sh syncHeaders) SetupHeadersForUpdate(src, dst ChainLightClient) ([]Header, error) {
 	logger := GetChainPairLogger(src, dst)
 	if err := ensureDifferentChains(src, dst); err != nil {
 		logger.Error("error ensuring different chains", err)
@@ -132,7 +132,7 @@ func (sh syncHeaders) SetupHeadersForUpdate(src, dst ChainICS02QuerierLightClien
 }
 
 // SetupBothHeadersForUpdate returns both `src` and `dst` chain's headers to update the clients on each chain
-func (sh syncHeaders) SetupBothHeadersForUpdate(src, dst ChainICS02QuerierLightClient) ([]Header, []Header, error) {
+func (sh syncHeaders) SetupBothHeadersForUpdate(src, dst ChainLightClient) ([]Header, []Header, error) {
 	logger := GetChainPairLogger(src, dst)
 	srcHs, err := sh.SetupHeadersForUpdate(src, dst)
 	if err != nil {

--- a/core/provers.go
+++ b/core/provers.go
@@ -33,8 +33,8 @@ type StateProver interface {
 type LightClient interface {
 	FinalityAware
 
-	// CreateMsgCreateClient creates a CreateClientMsg to this chain
-	CreateMsgCreateClient(clientID string, dstHeader Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error)
+	// CreateMsgCreateClient creates a MsgCreateClient for the counterparty chain
+	CreateMsgCreateClient(clientID string, selfHeader Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error)
 
 	// SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
 	// The order of the returned header slice should be as: [<intermediate headers>..., <update header>]

--- a/core/provers.go
+++ b/core/provers.go
@@ -31,21 +31,32 @@ type StateProver interface {
 
 // LightClient provides functions for creating and updating on-chain light clients on the counterparty chain
 type LightClient interface {
+	FinalityAware
+
 	// CreateMsgCreateClient creates a CreateClientMsg to this chain
 	CreateMsgCreateClient(clientID string, dstHeader Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error)
-
-	// GetLatestFinalizedHeader returns the latest finalized header on this chain
-	// The returned header is expected to be the latest one of headers that can be verified by the light client
-	GetLatestFinalizedHeader() (latestFinalizedHeader Header, err error)
 
 	// SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
 	// The order of the returned header slice should be as: [<intermediate headers>..., <update header>]
 	// if the header slice's length == 0 and err == nil, the relayer should skips the update-client
-	SetupHeadersForUpdate(dstChain ChainInfoICS02Querier, latestFinalizedHeader Header) ([]Header, error)
+	SetupHeadersForUpdate(counterparty FinalityAwareChain, latestFinalizedHeader Header) ([]Header, error)
 
 	// CheckRefreshRequired returns if the on-chain light client needs to be updated.
 	// For example, this requirement arises due to the trusting period mechanism.
 	CheckRefreshRequired(counterparty ChainInfoICS02Querier) (bool, error)
+}
+
+// FinalityAware provides the capability to determine the finality of the chain
+type FinalityAware interface {
+	// GetLatestFinalizedHeader returns the latest finalized header on this chain
+	// The returned header is expected to be the latest one of headers that can be verified by the light client
+	GetLatestFinalizedHeader() (latestFinalizedHeader Header, err error)
+}
+
+// FinalityAwareChain is FinalityAware + Chain
+type FinalityAwareChain interface {
+	FinalityAware
+	Chain
 }
 
 // ChainInfoICS02Querier is ChainInfo + ICS02Querier

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -37,9 +37,9 @@ func (pr *Prover) SetupForRelay(ctx context.Context) error {
 	return nil
 }
 
-// CreateMsgCreateClient creates a CreateClientMsg to this chain
-func (pr *Prover) CreateMsgCreateClient(clientID string, dstHeader core.Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error) {
-	h := dstHeader.(*mocktypes.Header)
+// CreateMsgCreateClient creates a MsgCreateClient for the counterparty chain
+func (pr *Prover) CreateMsgCreateClient(clientID string, selfHeader core.Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error) {
+	h := selfHeader.(*mocktypes.Header)
 	clientState := &mocktypes.ClientState{
 		LatestHeight: h.Height,
 	}

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -54,7 +54,7 @@ func (pr *Prover) CreateMsgCreateClient(clientID string, dstHeader core.Header, 
 }
 
 // SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
-func (pr *Prover) SetupHeadersForUpdate(dstChain core.ChainInfoICS02Querier, latestFinalizedHeader core.Header) ([]core.Header, error) {
+func (pr *Prover) SetupHeadersForUpdate(_ core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
 	return []core.Header{latestFinalizedHeader.(*mocktypes.Header)}, nil
 }
 


### PR DESCRIPTION
introduce the following interfaces
- `FinalityAware`
- `FinalityAwareChain`
- `ChainLightClient`

delete the following interface
- `ChainICS02QuerierLightClient`