### PR TITLE
fix height flag type

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -19,7 +19,7 @@ const (
 )
 
 func heightFlag(cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().Int64(flags.FlagHeight, 0, "Height of headers to fetch")
+	cmd.Flags().Uint64(flags.FlagHeight, 0, "Height of headers to fetch")
 	if err := viper.BindPFlag(flags.FlagHeight, cmd.Flags().Lookup(flags.FlagHeight)); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
height flag should be specified as uint64, but int64 is used
- https://github.com/hyperledger-labs/yui-relayer/blob/main/cmd/query.go#L52
- https://github.com/hyperledger-labs/yui-relayer/blob/main/cmd/query.go#L89
- https://github.com/hyperledger-labs/yui-relayer/blob/main/cmd/query.go#L122