### PR TITLE
core: remove `clientID` from CreateMsgCreateClient

### DIFF
--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -57,7 +57,7 @@ func (pr *Prover) ProveState(ctx core.QueryContext, path string, value []byte) (
 /* LightClient implementation */
 
 // CreateMsgCreateClient creates a MsgCreateClient for the counterparty chain
-func (pr *Prover) CreateMsgCreateClient(clientID string, selfHeader core.Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error) {
+func (pr *Prover) CreateMsgCreateClient(selfHeader core.Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error) {
 	ubdPeriod, err := pr.chain.QueryUnbondingPeriod()
 	if err != nil {
 		return nil, err

--- a/core/client.go
+++ b/core/client.go
@@ -42,7 +42,7 @@ func CreateClients(src, dst *ProvableChain) error {
 	}
 
 	{
-		msg, err := dst.CreateMsgCreateClient(src.Path().ClientID, dstH, srcAddr)
+		msg, err := dst.CreateMsgCreateClient(dstH, srcAddr)
 		if err != nil {
 			logger.Error(
 				"failed to create client",
@@ -54,7 +54,7 @@ func CreateClients(src, dst *ProvableChain) error {
 	}
 
 	{
-		msg, err := src.CreateMsgCreateClient(dst.Path().ClientID, srcH, dstAddr)
+		msg, err := src.CreateMsgCreateClient(srcH, dstAddr)
 		if err != nil {
 			logger.Error(
 				"failed to create client",

--- a/core/provers.go
+++ b/core/provers.go
@@ -34,7 +34,7 @@ type LightClient interface {
 	FinalityAware
 
 	// CreateMsgCreateClient creates a MsgCreateClient for the counterparty chain
-	CreateMsgCreateClient(clientID string, selfHeader Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error)
+	CreateMsgCreateClient(selfHeader Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error)
 
 	// SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
 	// The order of the returned header slice should be as: [<intermediate headers>..., <update header>]

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -38,7 +38,7 @@ func (pr *Prover) SetupForRelay(ctx context.Context) error {
 }
 
 // CreateMsgCreateClient creates a MsgCreateClient for the counterparty chain
-func (pr *Prover) CreateMsgCreateClient(clientID string, selfHeader core.Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error) {
+func (pr *Prover) CreateMsgCreateClient(selfHeader core.Header, signer sdk.AccAddress) (*clienttypes.MsgCreateClient, error) {
 	h := selfHeader.(*mocktypes.Header)
 	clientState := &mocktypes.ClientState{
 		LatestHeight: h.Height,


### PR DESCRIPTION
The clientID is determined during Tx execution on chain, so it cannot be specified externally.