### PR TITLE
Add `src-seqs` and `dst-seqs` option to `tx acks` and `tx relay`

### DIFF
--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -335,22 +335,16 @@ func relayAcksCmd(ctx *config.Context) *cobra.Command {
 }
 
 func tryFilterRelayPackets(sp *core.RelayPackets, srcSeq []uint64, dstSeq []uint64) error {
-	checkSequence := func(p core.PacketInfoList, selected []uint64) error {
-		if len(p) != len(selected) {
-			return fmt.Errorf("packet not found packetLength=%d selectedLength=%d", len(p), len(selected))
-		}
-		return nil
-	}
 	if len(srcSeq) > 0 {
 		sp.Src = sp.Src.Filter(srcSeq)
-		if err := checkSequence(sp.Src, srcSeq); err != nil {
-			return err
+		if len(sp.Src) != len(srcSeq) {
+			return fmt.Errorf("src packet not found packetLength=%d selectedLength=%d", len(sp.Src), len(srcSeq))
 		}
 	}
 	if len(dstSeq) > 0 {
 		sp.Dst = sp.Dst.Filter(dstSeq)
-		if err := checkSequence(sp.Dst, dstSeq); err != nil {
-			return err
+		if len(sp.Dst) != len(dstSeq) {
+			return fmt.Errorf("dst packet not found packetLength=%d selectedLength=%d", len(sp.Dst), len(dstSeq))
 		}
 	}
 	return nil

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -233,8 +233,8 @@ func relayMsgsCmd(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			srcSeq := getInt64Slice(flagSrcSeqs)
-			dstSeq := getInt64Slice(flagDstSeqs)
+			srcSeq := getUint64Slice(flagSrcSeqs)
+			dstSeq := getUint64Slice(flagDstSeqs)
 			if err = tryFilterRelayPackets(sp, srcSeq, dstSeq); err != nil {
 				return err
 			}
@@ -303,8 +303,8 @@ func relayAcksCmd(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			srcSeq := getInt64Slice(flagSrcSeqs)
-			dstSeq := getInt64Slice(flagDstSeqs)
+			srcSeq := getUint64Slice(flagSrcSeqs)
+			dstSeq := getUint64Slice(flagDstSeqs)
 			if err = tryFilterRelayPackets(sp, srcSeq, dstSeq); err != nil {
 				return err
 			}
@@ -356,7 +356,7 @@ func tryFilterRelayPackets(sp *core.RelayPackets, srcSeq []uint64, dstSeq []uint
 	return nil
 }
 
-func getInt64Slice(key string) []uint64 {
+func getUint64Slice(key string) []uint64 {
 	org := viper.GetIntSlice(key)
 	ret := make([]uint64, len(org))
 	for i, e := range org {

--- a/tests/cases/tm2tm/scripts/test-tx
+++ b/tests/cases/tm2tm/scripts/test-tx
@@ -19,9 +19,9 @@ echo "Before ibc1 balance: $(${RLY} query balance ibc1 ${TM_ADDRESS1})"
 
 ${RLY} tx transfer ibc01 ibc0 ibc1 100samoleans ${TM_ADDRESS1}
 sleep ${TX_INTERNAL}
-${RLY} tx relay --do-refresh ibc01
+${RLY} tx relay --do-refresh ibc01 --src-seqs 1
 sleep ${TX_INTERNAL}
-${RLY} tx acks --do-refresh ibc01
+${RLY} tx acks --do-refresh ibc01 --dst-seqs 1
 sleep ${TX_INTERNAL}
 
 echo "After ibc0 balance: $(${RLY} query balance ibc0 ${TM_ADDRESS0})"

--- a/tests/cases/tmmock2tmmock/scripts/test-tx
+++ b/tests/cases/tmmock2tmmock/scripts/test-tx
@@ -33,7 +33,7 @@ do
 done
 
 # relay the packet (recvPacket)
-${RLY} tx relay --do-refresh ibc01
+${RLY} tx relay --do-refresh ibc01 --src-seqs 1
 
 # wait for the finalization of the recvPacket execution
 for i in `seq $RETRY_COUNT`
@@ -48,7 +48,7 @@ do
 done
 
 # relay the ack for the packet (acknowledgePacket)
-${RLY} tx acks --do-refresh ibc01
+${RLY} tx acks --do-refresh ibc01 --dst-seqs 1
 
 # wait for the finalization of the recvPacket execution
 for i in `seq $RETRY_COUNT`


### PR DESCRIPTION
This PR allows the sequence to be specified with a command line option.
Checks if the specified sequence exists in the packet, or does not check if the sequence is unspecified.