### PR TITLE
Add context.Context to methods defined in chain, prover, and signer module interfaces

### DIFF
--- a/chains/tendermint/chain.go
+++ b/chains/tendermint/chain.go
@@ -143,7 +143,7 @@ func (c *Chain) SetupForRelay(ctx context.Context) error {
 }
 
 // LatestHeight queries the chain for the latest height and returns it
-func (c *Chain) LatestHeight() (ibcexported.Height, error) {
+func (c *Chain) LatestHeight(ctx context.Context) (ibcexported.Height, error) {
 	res, err := c.Client.Status(context.Background())
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func (c *Chain) LatestHeight() (ibcexported.Height, error) {
 	return clienttypes.NewHeight(version, uint64(res.SyncInfo.LatestBlockHeight)), nil
 }
 
-func (c *Chain) Timestamp(height ibcexported.Height) (time.Time, error) {
+func (c *Chain) Timestamp(ctx context.Context, height ibcexported.Height) (time.Time, error) {
 	ht := int64(height.GetRevisionHeight())
 	if header, err := c.Client.Header(context.TODO(), &ht); err != nil {
 		return time.Time{}, err
@@ -280,7 +280,7 @@ func (c *Chain) waitForCommit(txHash string) (*coretypes.ResultTx, error) {
 		// proofs of states updated up to height N are available.
 		// In order to make the proof of the state updated by a tx available just after `sendMsgs`,
 		// `waitForCommit` must wait until the latest height is greater than the tx height.
-		if height, err := c.LatestHeight(); err != nil {
+		if height, err := c.LatestHeight(context.TODO()); err != nil {
 			return fmt.Errorf("failed to obtain latest height: %v", err)
 		} else if height.GetRevisionHeight() <= uint64(resTx.Height) {
 			return fmt.Errorf("latest_height(%v) is less than or equal to tx_height(%v) yet", height, resTx.Height)

--- a/chains/tendermint/chain.go
+++ b/chains/tendermint/chain.go
@@ -193,7 +193,7 @@ func (c *Chain) sendMsgs(msgs []sdk.Msg) (*sdk.TxResponse, error) {
 
 	// call msgEventListener if needed
 	if c.msgEventListener != nil {
-		if err := c.msgEventListener.OnSentMsg(msgs); err != nil {
+		if err := c.msgEventListener.OnSentMsg(context.TODO(), msgs); err != nil {
 			logger.Error("failed to OnSendMsg call", err)
 			return res, nil
 		}

--- a/chains/tendermint/chain.go
+++ b/chains/tendermint/chain.go
@@ -404,7 +404,7 @@ func CalculateGas(
 	return simRes, uint64(txf.GasAdjustment() * float64(simRes.GasInfo.GasUsed)), nil
 }
 
-func (c *Chain) SendMsgs(msgs []sdk.Msg) ([]core.MsgID, error) {
+func (c *Chain) SendMsgs(ctx context.Context, msgs []sdk.Msg) ([]core.MsgID, error) {
 	// Broadcast those bytes
 	res, err := c.sendMsgs(msgs)
 	if err != nil {
@@ -420,7 +420,7 @@ func (c *Chain) SendMsgs(msgs []sdk.Msg) ([]core.MsgID, error) {
 	return msgIDs, nil
 }
 
-func (c *Chain) GetMsgResult(id core.MsgID) (core.MsgResult, error) {
+func (c *Chain) GetMsgResult(ctx context.Context, id core.MsgID) (core.MsgResult, error) {
 	msgID, ok := id.(*MsgID)
 	if !ok {
 		return nil, fmt.Errorf("unexpected message id type: %T", id)

--- a/chains/tendermint/light.go
+++ b/chains/tendermint/light.go
@@ -108,14 +108,14 @@ func (pr *Prover) LightClientWithoutTrust(db dbm.DB) (*light.Client, error) {
 	prov := pr.LightHTTP()
 
 	if err := retry.Do(func() error {
-		h, err := pr.chain.LatestHeight()
+		h, err := pr.chain.LatestHeight(context.TODO())
 		switch {
 		case err != nil:
 			return err
 		case h.GetRevisionHeight() == 0:
 			return fmt.Errorf("shouldn't be here")
 		default:
-			t, err := pr.chain.Timestamp(h)
+			t, err := pr.chain.Timestamp(context.TODO(), h)
 			if err != nil {
 				return err
 			}

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -63,7 +63,7 @@ func (pr *Prover) ProveHostConsensusState(ctx core.QueryContext, height ibcexpor
 /* LightClient implementation */
 
 // CreateInitialLightClientState creates a pair of ClientState and ConsensusState submitted to the counterparty chain as MsgCreateClient
-func (pr *Prover) CreateInitialLightClientState(height ibcexported.Height) (ibcexported.ClientState, ibcexported.ConsensusState, error) {
+func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height ibcexported.Height) (ibcexported.ClientState, ibcexported.ConsensusState, error) {
 	var tmHeight int64
 	if height != nil {
 		tmHeight = int64(height.GetRevisionHeight())
@@ -90,7 +90,7 @@ func (pr *Prover) CreateInitialLightClientState(height ibcexported.Height) (ibce
 }
 
 // SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
-func (pr *Prover) SetupHeadersForUpdate(counterparty core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
+func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
 	self := pr.chain
 	// make copy of header stored in mop
 	tmp := latestFinalizedHeader.(*tmclient.Header)
@@ -131,7 +131,7 @@ func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, er
 	return pr.UpdateLightClient(0)
 }
 
-func (pr *Prover) CheckRefreshRequired(counterparty core.ChainInfoICS02Querier) (bool, error) {
+func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.ChainInfoICS02Querier) (bool, error) {
 	cpQueryHeight, err := counterparty.LatestHeight(context.TODO())
 	if err != nil {
 		return false, fmt.Errorf("failed to get the latest height of the counterparty chain: %v", err)

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -96,7 +96,7 @@ func (pr *Prover) SetupHeadersForUpdate(counterparty core.FinalityAwareChain, la
 	tmp := latestFinalizedHeader.(*tmclient.Header)
 	h := *tmp
 
-	cph, err := counterparty.LatestHeight()
+	cph, err := counterparty.LatestHeight(context.TODO())
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, er
 }
 
 func (pr *Prover) CheckRefreshRequired(counterparty core.ChainInfoICS02Querier) (bool, error) {
-	cpQueryHeight, err := counterparty.LatestHeight()
+	cpQueryHeight, err := counterparty.LatestHeight(context.TODO())
 	if err != nil {
 		return false, fmt.Errorf("failed to get the latest height of the counterparty chain: %v", err)
 	}
@@ -159,12 +159,12 @@ func (pr *Prover) CheckRefreshRequired(counterparty core.ChainInfoICS02Querier) 
 	}
 	lcLastTimestamp := time.Unix(0, int64(cons.GetTimestamp()))
 
-	selfQueryHeight, err := pr.chain.LatestHeight()
+	selfQueryHeight, err := pr.chain.LatestHeight(context.TODO())
 	if err != nil {
 		return false, fmt.Errorf("failed to get the latest height of the self chain: %v", err)
 	}
 
-	selfTimestamp, err := pr.chain.Timestamp(selfQueryHeight)
+	selfTimestamp, err := pr.chain.Timestamp(context.TODO(), selfQueryHeight)
 	if err != nil {
 		return false, fmt.Errorf("failed to get timestamp of the self chain: %v", err)
 	}

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -127,7 +127,7 @@ func (pr *Prover) SetupHeadersForUpdate(counterparty core.FinalityAwareChain, la
 }
 
 // GetLatestFinalizedHeader returns the latest finalized header
-func (pr *Prover) GetLatestFinalizedHeader() (core.Header, error) {
+func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, error) {
 	return pr.UpdateLightClient(0)
 }
 

--- a/chains/tendermint/query.go
+++ b/chains/tendermint/query.go
@@ -211,7 +211,7 @@ func (c *Chain) QueryUnfinalizedRelayPackets(ctx core.QueryContext, counterparty
 	}
 
 	var counterpartyCtx core.QueryContext
-	if counterpartyH, err := counterparty.GetLatestFinalizedHeader(); err != nil {
+	if counterpartyH, err := counterparty.GetLatestFinalizedHeader(context.TODO()); err != nil {
 		return nil, fmt.Errorf("failed to get latest finalized header: error=%w height=%v", err, ctx.Height())
 	} else {
 		counterpartyCtx = core.NewQueryContext(context.TODO(), counterpartyH.GetHeight())
@@ -264,7 +264,7 @@ func (c *Chain) QueryUnfinalizedRelayAcknowledgements(ctx core.QueryContext, cou
 	}
 
 	var counterpartyCtx core.QueryContext
-	if counterpartyH, err := counterparty.GetLatestFinalizedHeader(); err != nil {
+	if counterpartyH, err := counterparty.GetLatestFinalizedHeader(context.TODO()); err != nil {
 		return nil, fmt.Errorf("failed to get latest finalized header: error=%w height=%v", err, ctx.Height())
 	} else {
 		counterpartyCtx = core.NewQueryContext(context.TODO(), counterpartyH.GetHeight())

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -56,7 +56,7 @@ func queryClientCmd(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			latestHeight, err := c.LatestHeight()
+			latestHeight, err := c.LatestHeight(context.TODO())
 			if err != nil {
 				return err
 			}
@@ -98,7 +98,7 @@ func queryConnection(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			latestHeight, err := c.LatestHeight()
+			latestHeight, err := c.LatestHeight(context.TODO())
 			if err != nil {
 				return err
 			}
@@ -136,7 +136,7 @@ func queryChannel(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			latestHeight, err := c.LatestHeight()
+			latestHeight, err := c.LatestHeight(context.TODO())
 			if err != nil {
 				return err
 			}
@@ -175,7 +175,7 @@ func queryChannelUpgrade(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			latestHeight, err := c.LatestHeight()
+			latestHeight, err := c.LatestHeight(context.TODO())
 			if err != nil {
 				return err
 			}
@@ -221,7 +221,7 @@ func queryBalanceCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			h, err := chain.LatestHeight()
+			h, err := chain.LatestHeight(context.TODO())
 			if err != nil {
 				return err
 			}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -81,7 +81,7 @@ func createClientsCmd(ctx *config.Context) *cobra.Command {
 				return err
 			} else if height == 0 {
 				srcHeight = nil
-			} else if latestHeight, err := c[src].LatestHeight(); err != nil {
+			} else if latestHeight, err := c[src].LatestHeight(context.TODO()); err != nil {
 				return fmt.Errorf("failed to get the latest height of src chain: %v", err)
 			} else {
 				srcHeight = clienttypes.NewHeight(latestHeight.GetRevisionNumber(), height)
@@ -93,7 +93,7 @@ func createClientsCmd(ctx *config.Context) *cobra.Command {
 				return err
 			} else if height == 0 {
 				dstHeight = nil
-			} else if latestHeight, err := c[dst].LatestHeight(); err != nil {
+			} else if latestHeight, err := c[dst].LatestHeight(context.TODO()); err != nil {
 				return fmt.Errorf("failed to get the latest height of dst chain: %v", err)
 			} else {
 				dstHeight = clienttypes.NewHeight(latestHeight.GetRevisionNumber(), height)

--- a/core/chain.go
+++ b/core/chain.go
@@ -101,10 +101,10 @@ type ChainInfo interface {
 	//
 	// NOTE: The returned height does not have to be finalized.
 	// If a finalized height/header is required, the `Prover`'s `GetLatestFinalizedHeader` function should be called instead.
-	LatestHeight() (ibcexported.Height, error)
+	LatestHeight(ctx context.Context) (ibcexported.Height, error)
 
 	// Timestamp returns the block timestamp
-	Timestamp(ibcexported.Height) (time.Time, error)
+	Timestamp(ctx context.Context, height ibcexported.Height) (time.Time, error)
 
 	// AverageBlockTime returns the average time required for each new block to be committed
 	AverageBlockTime() time.Duration

--- a/core/chain.go
+++ b/core/chain.go
@@ -113,7 +113,7 @@ type ChainInfo interface {
 // MsgEventListener is a listener that listens a msg send to the chain
 type MsgEventListener interface {
 	// OnSentMsg is a callback functoin that is called when a msg send to the chain
-	OnSentMsg(msgs []sdk.Msg) error
+	OnSentMsg(ctx context.Context, msgs []sdk.Msg) error
 }
 
 // IBCQuerier is an interface to the state of IBC

--- a/core/chain.go
+++ b/core/chain.go
@@ -78,11 +78,11 @@ type Chain interface {
 	// SendMsgs sends msgs to the chain and waits for them to be included in blocks.
 	// This function returns err=nil only if all the msgs executed successfully at the blocks.
 	// It should be noted that the block is not finalized at that point and can be reverted afterwards.
-	SendMsgs(msgs []sdk.Msg) ([]MsgID, error)
+	SendMsgs(ctx context.Context, msgs []sdk.Msg) ([]MsgID, error)
 
 	// GetMsgResult returns the execution result of `sdk.Msg` specified by `MsgID`
 	// If the msg is not included in any block, this function waits for inclusion.
-	GetMsgResult(id MsgID) (MsgResult, error)
+	GetMsgResult(ctx context.Context, id MsgID) (MsgResult, error)
 
 	// RegisterMsgEventListener registers a given EventListener to the chain
 	RegisterMsgEventListener(MsgEventListener)

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -219,7 +219,7 @@ func CancelChannelUpgrade(chain, cp *ProvableChain, settlementInterval time.Dura
 			continue
 		}
 
-		cpHeaders, err := cp.SetupHeadersForUpdate(chain, sh.GetLatestFinalizedHeader(cp.ChainID()))
+		cpHeaders, err := cp.SetupHeadersForUpdate(context.TODO(), chain, sh.GetLatestFinalizedHeader(cp.ChainID()))
 		if err != nil {
 			logger.Error("failed to set up headers for LC update", err)
 			return err

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -79,10 +79,10 @@ func InitChannelUpgrade(chain, cp *ProvableChain, upgradeFields chantypes.Upgrad
 	logger := GetChannelLogger(chain.Chain)
 	defer logger.TimeTrack(time.Now(), "InitChannelUpgrade")
 
-	if h, err := chain.LatestHeight(); err != nil {
+	if h, err := chain.LatestHeight(context.TODO()); err != nil {
 		logger.Error("failed to get the latest height", err)
 		return err
-	} else if cpH, err := cp.LatestHeight(); err != nil {
+	} else if cpH, err := cp.LatestHeight(context.TODO()); err != nil {
 		logger.Error("failed to get the latest height of the counterparty chain", err)
 		return err
 	} else if chann, cpChann, err := QueryChannelPair(
@@ -617,7 +617,7 @@ func queryCanTransitionToFlushComplete(chain interface {
 	ChainInfo
 	ICS04Querier
 }) (bool, error) {
-	if h, err := chain.LatestHeight(); err != nil {
+	if h, err := chain.LatestHeight(context.TODO()); err != nil {
 		return false, err
 	} else {
 		return chain.QueryCanTransitionToFlushComplete(NewQueryContext(context.TODO(), h))
@@ -648,13 +648,13 @@ func querySettledChannelUpgradePair(
 
 	// prepare QueryContext's based on the latest heights
 	var srcLatestCtx, dstLatestCtx QueryContext
-	if h, err := src.LatestHeight(); err != nil {
+	if h, err := src.LatestHeight(context.TODO()); err != nil {
 		logger.Error("failed to get the latest height of the src chain", err)
 		return nil, nil, false, err
 	} else {
 		srcLatestCtx = NewQueryContext(context.TODO(), h)
 	}
-	if h, err := dst.LatestHeight(); err != nil {
+	if h, err := dst.LatestHeight(context.TODO()); err != nil {
 		logger.Error("failed to get the latest height of the dst chain", err)
 		return nil, nil, false, err
 	} else {
@@ -712,7 +712,7 @@ func upgradeAlreadyTimedOut(
 	cpChanUpg *chantypes.QueryUpgradeResponse,
 ) (bool, error) {
 	height := ctx.Height().(clienttypes.Height)
-	timestamp, err := chain.Timestamp(height)
+	timestamp, err := chain.Timestamp(context.TODO(), height)
 	if err != nil {
 		return false, err
 	}

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -117,7 +117,7 @@ func InitChannelUpgrade(chain, cp *ProvableChain, upgradeFields chantypes.Upgrad
 
 	msg := chain.Path().ChanUpgradeInit(upgradeFields, addr)
 
-	if _, err := chain.SendMsgs([]sdk.Msg{msg}); err != nil {
+	if _, err := chain.SendMsgs(context.TODO(), []sdk.Msg{msg}); err != nil {
 		logger.Error("failed to send MsgChannelUpgradeInit", err)
 		return err
 	} else {
@@ -260,7 +260,7 @@ func CancelChannelUpgrade(chain, cp *ProvableChain, settlementInterval time.Dura
 		// NOTE: A call of SendMsgs for each msg is executed separately to avoid using multicall for eth.
 		//       This is just a workaround and should be fixed in the future.
 		for _, msg := range msgs {
-			if _, err := chain.SendMsgs([]sdk.Msg{msg}); err != nil {
+			if _, err := chain.SendMsgs(context.TODO(), []sdk.Msg{msg}); err != nil {
 				logger.Error("failed to send a msg to cancel the channel upgrade", err)
 				return err
 			}

--- a/core/channel.go
+++ b/core/channel.go
@@ -87,7 +87,7 @@ func checkChannelCreateReady(src, dst *ProvableChain, logger *log.RelayLogger) (
 			return chantypes.UNINITIALIZED, nil
 		}
 
-		latestHeight, err := pc.LatestHeight()
+		latestHeight, err := pc.LatestHeight(context.TODO())
 		if err != nil {
 			return chantypes.UNINITIALIZED, err
 		}
@@ -268,13 +268,13 @@ func querySettledChannelPair(
 	}
 
 	var srcLatestCtx, dstLatestCtx QueryContext
-	if h, err := src.LatestHeight(); err != nil {
+	if h, err := src.LatestHeight(context.TODO()); err != nil {
 		logger.Error("failed to get the latest height of the src chain", err)
 		return nil, nil, false, err
 	} else {
 		srcLatestCtx = NewQueryContext(context.TODO(), h)
 	}
-	if h, err := dst.LatestHeight(); err != nil {
+	if h, err := dst.LatestHeight(context.TODO()); err != nil {
 		logger.Error("failed to get the latest height of the dst chain", err)
 		return nil, nil, false, err
 	} else {

--- a/core/client.go
+++ b/core/client.go
@@ -85,7 +85,7 @@ func CreateClients(pathName string, src, dst *ProvableChain, srcHeight, dstHeigh
 			return err
 		}
 
-		cs, cons, err := dst.CreateInitialLightClientState(dstHeight)
+		cs, cons, err := dst.CreateInitialLightClientState(context.TODO(), dstHeight)
 		if err != nil {
 			logger.Error("failed to create initial light client state", err)
 			return err
@@ -107,7 +107,7 @@ func CreateClients(pathName string, src, dst *ProvableChain, srcHeight, dstHeigh
 			return err
 		}
 
-		cs, cons, err := src.CreateInitialLightClientState(srcHeight)
+		cs, cons, err := src.CreateInitialLightClientState(context.TODO(), srcHeight)
 		if err != nil {
 			logger.Error("failed to create initial light client state", err)
 			return err

--- a/core/client.go
+++ b/core/client.go
@@ -20,7 +20,7 @@ func checkCreateClientsReady(src, dst *ProvableChain, logger *log.RelayLogger) (
 	}
 
 	getState := func(pc *ProvableChain) (*clienttypes.QueryClientStateResponse, error) {
-		latestHeight, err := pc.LatestHeight()
+		latestHeight, err := pc.LatestHeight(context.TODO())
 		if err != nil {
 			return nil, err
 		}

--- a/core/config.go
+++ b/core/config.go
@@ -152,7 +152,7 @@ func SyncChainConfigFromEvents(pathName string, msgIDs []MsgID, chain *ProvableC
 		if msgID == nil {
 			continue
 		}
-		msgRes, err := chain.Chain.GetMsgResult(msgID)
+		msgRes, err := chain.Chain.GetMsgResult(context.TODO(), msgID)
 		if err != nil {
 			return fmt.Errorf("failed to get message result: %v", err)
 		} else if ok, failureReason := msgRes.Status(); !ok {

--- a/core/connection.go
+++ b/core/connection.go
@@ -96,7 +96,7 @@ func checkConnectionCreateReady(src, dst *ProvableChain, logger *log.RelayLogger
 			return conntypes.UNINITIALIZED, nil
 		}
 
-		latestHeight, err := pc.LatestHeight()
+		latestHeight, err := pc.LatestHeight(context.TODO())
 		if err != nil {
 			return conntypes.UNINITIALIZED, err
 		}
@@ -351,13 +351,13 @@ func querySettledConnectionPair(
 	}
 
 	var srcLatestCtx, dstLatestCtx QueryContext
-	if h, err := src.LatestHeight(); err != nil {
+	if h, err := src.LatestHeight(context.TODO()); err != nil {
 		logger.Error("failed to get the latest height of the src chain", err)
 		return nil, nil, false, err
 	} else {
 		srcLatestCtx = NewQueryContext(context.TODO(), h)
 	}
-	if h, err := dst.LatestHeight(); err != nil {
+	if h, err := dst.LatestHeight(context.TODO()); err != nil {
 		logger.Error("failed to get the latest height of the dst chain", err)
 		return nil, nil, false, err
 	} else {

--- a/core/headers.go
+++ b/core/headers.go
@@ -128,7 +128,7 @@ func (sh syncHeaders) SetupHeadersForUpdate(src, dst ChainLightClient) ([]Header
 		logger.Error("error ensuring different chains", err)
 		return nil, err
 	}
-	return src.SetupHeadersForUpdate(dst, sh.GetLatestFinalizedHeader(src.ChainID()))
+	return src.SetupHeadersForUpdate(context.TODO(), dst, sh.GetLatestFinalizedHeader(src.ChainID()))
 }
 
 // SetupBothHeadersForUpdate returns both `src` and `dst` chain's headers to update the clients on each chain

--- a/core/headers.go
+++ b/core/headers.go
@@ -77,12 +77,12 @@ func (sh *syncHeaders) Updates(src, dst ChainInfoLightClient) error {
 		return err
 	}
 
-	srcHeader, err := src.GetLatestFinalizedHeader()
+	srcHeader, err := src.GetLatestFinalizedHeader(context.TODO())
 	if err != nil {
 		logger.Error("error getting latest finalized header of src", err)
 		return err
 	}
-	dstHeader, err := dst.GetLatestFinalizedHeader()
+	dstHeader, err := dst.GetLatestFinalizedHeader(context.TODO())
 	if err != nil {
 		logger.Error("error getting latest finalized header of dst", err)
 		return err

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -69,7 +69,7 @@ func getQueryContext(chain *ProvableChain, sh SyncHeaders, useFinalizedHeader bo
 	if useFinalizedHeader {
 		return sh.GetQueryContext(chain.ChainID()), nil
 	} else {
-		height, err := chain.LatestHeight()
+		height, err := chain.LatestHeight(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +585,7 @@ func (st *naiveStrategyMetrics) updateBacklogMetrics(ctx context.Context, src, d
 
 	if len(newSrcBacklog) > 0 {
 		oldestHeight := newSrcBacklog[0].EventHeight
-		oldestTimestamp, err := src.Timestamp(oldestHeight)
+		oldestTimestamp, err := src.Timestamp(context.TODO(), oldestHeight)
 		if err != nil {
 			return fmt.Errorf("failed to get the timestamp of block[%d] on the src chain: %v", oldestHeight, err)
 		}
@@ -595,7 +595,7 @@ func (st *naiveStrategyMetrics) updateBacklogMetrics(ctx context.Context, src, d
 	}
 	if len(newDstBacklog) > 0 {
 		oldestHeight := newDstBacklog[0].EventHeight
-		oldestTimestamp, err := dst.Timestamp(oldestHeight)
+		oldestTimestamp, err := dst.Timestamp(context.TODO(), oldestHeight)
 		if err != nil {
 			return fmt.Errorf("failed to get the timestamp of block[%d] on the dst chain: %v", oldestHeight, err)
 		}

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -506,14 +506,14 @@ func (st *NaiveStrategy) UpdateClients(src, dst *ProvableChain, doExecuteRelaySr
 	// check if LC refresh is needed
 	if !needsUpdateForSrc && doRefresh {
 		var err error
-		needsUpdateForSrc, err = dst.CheckRefreshRequired(src)
+		needsUpdateForSrc, err = dst.CheckRefreshRequired(context.TODO(), src)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if the LC on the src chain needs to be refreshed: %v", err)
 		}
 	}
 	if !needsUpdateForDst && doRefresh {
 		var err error
-		needsUpdateForDst, err = src.CheckRefreshRequired(dst)
+		needsUpdateForDst, err = src.CheckRefreshRequired(context.TODO(), dst)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if the LC on the dst chain needs to be refreshed: %v", err)
 		}

--- a/core/packet-tx.go
+++ b/core/packet-tx.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -15,7 +16,7 @@ func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr string, t
 		timeoutTimestamp uint64
 	)
 
-	h, err := dst.LatestHeight()
+	h, err := dst.LatestHeight(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/core/provers.go
+++ b/core/provers.go
@@ -41,16 +41,16 @@ type LightClient interface {
 	// CreateInitialLightClientState returns a pair of ClientState and ConsensusState based on the state of the self chain at `height`.
 	// These states will be submitted to the counterparty chain as MsgCreateClient.
 	// If `height` is nil, the latest finalized height is selected automatically.
-	CreateInitialLightClientState(height exported.Height) (exported.ClientState, exported.ConsensusState, error)
+	CreateInitialLightClientState(ctx context.Context, height exported.Height) (exported.ClientState, exported.ConsensusState, error)
 
 	// SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
 	// The order of the returned header slice should be as: [<intermediate headers>..., <update header>]
 	// if the header slice's length == 0 and err == nil, the relayer should skips the update-client
-	SetupHeadersForUpdate(counterparty FinalityAwareChain, latestFinalizedHeader Header) ([]Header, error)
+	SetupHeadersForUpdate(ctx context.Context, counterparty FinalityAwareChain, latestFinalizedHeader Header) ([]Header, error)
 
 	// CheckRefreshRequired returns if the on-chain light client needs to be updated.
 	// For example, this requirement arises due to the trusting period mechanism.
-	CheckRefreshRequired(counterparty ChainInfoICS02Querier) (bool, error)
+	CheckRefreshRequired(ctx context.Context, counterparty ChainInfoICS02Querier) (bool, error)
 }
 
 // FinalityAware provides the capability to determine the finality of the chain

--- a/core/provers.go
+++ b/core/provers.go
@@ -57,7 +57,7 @@ type LightClient interface {
 type FinalityAware interface {
 	// GetLatestFinalizedHeader returns the latest finalized header on this chain
 	// The returned header is expected to be the latest one of headers that can be verified by the light client
-	GetLatestFinalizedHeader() (latestFinalizedHeader Header, err error)
+	GetLatestFinalizedHeader(ctx context.Context) (latestFinalizedHeader Header, err error)
 }
 
 // FinalityAwareChain is FinalityAware + Chain

--- a/core/relayMsgs.go
+++ b/core/relayMsgs.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -78,7 +79,7 @@ func (r *RelayMsgs) Send(src, dst Chain) {
 			)}
 
 			// Submit the transactions to src chain and update its status
-			msgIDs, err := src.SendMsgs(msgs)
+			msgIDs, err := src.SendMsgs(context.TODO(), msgs)
 			if err != nil {
 				logger.Error("failed to send msgs", err)
 			} else {
@@ -105,7 +106,7 @@ func (r *RelayMsgs) Send(src, dst Chain) {
 			"side", "src",
 		)}
 
-		msgIDs, err := src.SendMsgs(msgs)
+		msgIDs, err := src.SendMsgs(context.TODO(), msgs)
 		if err != nil {
 			logger.Error("failed to send msgs", err)
 		} else {
@@ -141,7 +142,7 @@ func (r *RelayMsgs) Send(src, dst Chain) {
 			)}
 
 			// Submit the transaction to dst chain and update its status
-			msgIDs, err := dst.SendMsgs(msgs)
+			msgIDs, err := dst.SendMsgs(context.TODO(), msgs)
 			if err != nil {
 				logger.Error("failed to send msgs", err)
 			} else {
@@ -168,7 +169,7 @@ func (r *RelayMsgs) Send(src, dst Chain) {
 			"side", "dst",
 		)}
 
-		msgIDs, err := dst.SendMsgs(msgs)
+		msgIDs, err := dst.SendMsgs(context.TODO(), msgs)
 		if err != nil {
 			logger.Error("failed to send msgs", err)
 		} else {

--- a/core/send.go
+++ b/core/send.go
@@ -16,7 +16,7 @@ func GetFinalizedMsgResult(chain ProvableChain, msgID MsgID) (MsgResult, error) 
 
 	if err := retry.Do(func() error {
 		// query LFH for each retry because it can proceed.
-		lfHeader, err := chain.GetLatestFinalizedHeader()
+		lfHeader, err := chain.GetLatestFinalizedHeader(context.TODO())
 		if err != nil {
 			return fmt.Errorf("failed to get latest finalized header: %v", err)
 		}

--- a/core/send.go
+++ b/core/send.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -21,7 +22,7 @@ func GetFinalizedMsgResult(chain ProvableChain, msgID MsgID) (MsgResult, error) 
 		}
 
 		// query MsgResult for each retry because it can be included in a different block because of reorg
-		msgRes, err = chain.GetMsgResult(msgID)
+		msgRes, err = chain.GetMsgResult(context.TODO(), msgID)
 		if err != nil {
 			return retry.Unrecoverable(fmt.Errorf("failed to get message result: %v", err))
 		} else if ok, failureReason := msgRes.Status(); !ok {

--- a/core/service.go
+++ b/core/service.go
@@ -170,7 +170,7 @@ func (srv *RelayService) shouldExecuteRelay(seqs *RelayPackets) (bool, bool) {
 	dstRelay := false
 
 	if len(seqs.Src) > 0 {
-		tsDst, err := srv.src.Timestamp(seqs.Src[0].EventHeight)
+		tsDst, err := srv.src.Timestamp(context.TODO(), seqs.Src[0].EventHeight)
 		if err != nil {
 			return false, false
 		}
@@ -180,7 +180,7 @@ func (srv *RelayService) shouldExecuteRelay(seqs *RelayPackets) (bool, bool) {
 	}
 
 	if len(seqs.Dst) > 0 {
-		tsSrc, err := srv.dst.Timestamp(seqs.Dst[0].EventHeight)
+		tsSrc, err := srv.dst.Timestamp(context.TODO(), seqs.Dst[0].EventHeight)
 		if err != nil {
 			return false, false
 		}

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -44,7 +44,7 @@ func (pr *Prover) SetupForRelay(ctx context.Context) error {
 
 // CreateInitialLightClientState creates a pair of ClientState and ConsensusState for building MsgCreateClient submitted to the counterparty chain
 func (pr *Prover) CreateInitialLightClientState(height exported.Height) (exported.ClientState, exported.ConsensusState, error) {
-	if head, err := pr.GetLatestFinalizedHeader(); err != nil {
+	if head, err := pr.GetLatestFinalizedHeader(context.TODO()); err != nil {
 		return nil, nil, fmt.Errorf("failed to get the latest finalized header: %v", err)
 	} else if height == nil {
 		height = head.GetHeight()
@@ -106,7 +106,7 @@ func (pr *Prover) getDelayedLatestFinalizedHeight() (exported.Height, error) {
 }
 
 // GetLatestFinalizedHeader returns the latest finalized header
-func (pr *Prover) GetLatestFinalizedHeader() (core.Header, error) {
+func (pr *Prover) GetLatestFinalizedHeader(context.Context) (core.Header, error) {
 	if latestFinalizedHeight, err := pr.getDelayedLatestFinalizedHeight(); err != nil {
 		return nil, err
 	} else {

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -60,7 +60,7 @@ func (pr *Prover) CreateInitialLightClientState(height exported.Height) (exporte
 	}
 
 	var consensusState exported.ConsensusState
-	if timestamp, err := pr.chain.Timestamp(height); err != nil {
+	if timestamp, err := pr.chain.Timestamp(context.TODO(), height); err != nil {
 		return nil, nil, fmt.Errorf("get timestamp at height@%v: %v", height, err)
 	} else {
 		consensusState = &mocktypes.ConsensusState{
@@ -77,7 +77,7 @@ func (pr *Prover) SetupHeadersForUpdate(_ core.FinalityAwareChain, latestFinaliz
 }
 
 func (pr *Prover) createMockHeader(height exported.Height) (core.Header, error) {
-	timestamp, err := pr.chain.Timestamp(height)
+	timestamp, err := pr.chain.Timestamp(context.TODO(), height)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block timestamp at height:%v", height)
 	}
@@ -91,7 +91,7 @@ func (pr *Prover) createMockHeader(height exported.Height) (core.Header, error) 
 }
 
 func (pr *Prover) getDelayedLatestFinalizedHeight() (exported.Height, error) {
-	height, err := pr.chain.LatestHeight()
+	height, err := pr.chain.LatestHeight(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest height: %v", err)
 	}

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -43,7 +43,7 @@ func (pr *Prover) SetupForRelay(ctx context.Context) error {
 }
 
 // CreateInitialLightClientState creates a pair of ClientState and ConsensusState for building MsgCreateClient submitted to the counterparty chain
-func (pr *Prover) CreateInitialLightClientState(height exported.Height) (exported.ClientState, exported.ConsensusState, error) {
+func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height exported.Height) (exported.ClientState, exported.ConsensusState, error) {
 	if head, err := pr.GetLatestFinalizedHeader(context.TODO()); err != nil {
 		return nil, nil, fmt.Errorf("failed to get the latest finalized header: %v", err)
 	} else if height == nil {
@@ -72,7 +72,7 @@ func (pr *Prover) CreateInitialLightClientState(height exported.Height) (exporte
 }
 
 // SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
-func (pr *Prover) SetupHeadersForUpdate(_ core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
+func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
 	return []core.Header{latestFinalizedHeader.(*mocktypes.Header)}, nil
 }
 
@@ -115,7 +115,7 @@ func (pr *Prover) GetLatestFinalizedHeader(context.Context) (core.Header, error)
 }
 
 // CheckRefreshRequired always returns false because mock clients don't need refresh.
-func (pr *Prover) CheckRefreshRequired(dst core.ChainInfoICS02Querier) (bool, error) {
+func (pr *Prover) CheckRefreshRequired(ctx context.Context, dst core.ChainInfoICS02Querier) (bool, error) {
 	return false, nil
 }
 

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -1,6 +1,8 @@
 package signer
 
 import (
+	"context"
+
 	"github.com/cosmos/gogoproto/proto"
 )
 
@@ -11,6 +13,6 @@ type SignerConfig interface {
 }
 
 type Signer interface {
-	Sign(digest []byte) (signature []byte, err error)
-	GetPublicKey() ([]byte, error)
+	Sign(ctx context.Context, digest []byte) (signature []byte, err error)
+	GetPublicKey(ctx context.Context) ([]byte, error)
 }


### PR DESCRIPTION
# Description

This PR is the first step to integrate with OpenTelemetry to improve the observability of yui-relayer.
I will divide the whole integration process into the following phases:

1. Add a `context.Context` argument to the methods defined in chain module interfaces, prover module interfaces, and signer module interfaces
2. Fix method signatures of the modules in other repositories
    - https://github.com/datachainlab/ibc-hd-signer/pull/3
    - https://github.com/datachainlab/ethereum-ibc-relay-chain/pull/63
    - https://github.com/datachainlab/ethereum-ibc-relay-prover/pull/32
    - https://github.com/datachainlab/lcp-go/pull/40
    - https://github.com/datachainlab/besu-ibc-relay-prover/pull/15
    - https://github.com/datachainlab/ibc-parlia-relay/pull/51
4. Add a `context.Context` argument to appropriate methods that are unlikely to be used from other repositories
    - e.g. methods of `core.StrategyI`, `core.SyncHeaders`, and so on
5. Replace `context.TODO()` with an appropriate context
6. Integrate with OpenTelemetry

This PR includes the changes in the first phase and I have added a `context.Context` argument to the methods likely to access external services or create a goroutine, and `context.TODO()` to the method calls in a mechanical manner.
Although the main purpose is to improve the observability, I think it is common to add a `context.Context` argument to such methods, whose process we need to cancel in some occasions.

Note that I don't add a `context.Context` argument to the methods that are likely to be a mere getter.

# Considerations

This PR includes breaking changes, but they are acceptable according to [Module version numbering](https://go.dev/doc/modules/version-numbers):

> Signals that the module is still in development and unstable. This release carries no backward compatibility or stability guarantees.

# Note

I have examined the following interfaces:

```
% git grep -E 'type \w+ interface \{' ':!chains'
config/module.go:9:type ModuleI interface {
core/chain.go:59:type Chain interface {
core/chain.go:96:type ChainInfo interface {
core/chain.go:114:type MsgEventListener interface {
core/chain.go:120:type IBCQuerier interface {
core/chain.go:127:type ICS02Querier interface {
core/chain.go:137:type ICS03Querier interface {
core/chain.go:143:type ICS04Querier interface {
core/chain.go:173:type ICS20Querier interface {
core/chain.go:181:type LightClientICS04Querier interface {
core/chain.go:187:type QueryContext interface {
core/config.go:28:type ConfigI interface {
core/config.go:50:type ChainConfig interface {
core/config.go:57:type ProverConfig interface {
core/headers.go:12:type Header interface {
core/headers.go:19:type SyncHeaders interface {
core/headers.go:37:type ChainInfoLightClient interface {
core/headers.go:43:type ChainLightClient interface {
core/msg.go:11:type MsgID interface {
core/msg.go:17:type MsgResult interface {
core/msg.go:30:type MsgEventLog interface {
core/provers.go:13:type Prover interface {
core/provers.go:28:type StateProver interface {
core/provers.go:38:type LightClient interface {
core/provers.go:57:type FinalityAware interface {
core/provers.go:64:type FinalityAwareChain interface {
core/provers.go:70:type ChainInfoICS02Querier interface {
core/strategies.go:9:type StrategyI interface {
metrics/metrics.go:30:type ExporterConfig interface {
signer/signer.go:9:type SignerConfig interface {
```

And here is my note on whether to add a context argument:

* Chain
    - This interface embeds `ChainInfo`, `IBCQuerier`, and `ICS20Querier`
    - Example implementations:
        - `github.com/datachainlab/ethereum-ibc-relay-chain/pkg/relay/ethereum.Chain`
        - `github.com/hyperledger-labs/yui-relayer/chains/tendermint.Chain`
    - All the methods of `IBCQuerier` and `ICS20Querier` have `QueryContext` containing `context.Context` as the first argument, so we don't need to change the signature
    - Other methods except for `SendMsgs`, `GetMsgResult`, `LatestHeight`, and `Timestamp` are expected to be simple getters, setters, or fixed values, so we don't need a context
* MsgEventListener
    - I could not find any implementations but some modules may access external services, so I have added a `context.Context` argument
* ConfigI
    - The method `UpdatePahtConfig` is unlikely to access external services or create a goroutine, so we don't need to change the signature
* ChainConfig
    - The methods `Build` and `Validate` are likely to be so simple that we don't need a context
* ProverConfig
    - Same as ChainConfig
* SyncHeaders
    - This interface is used internally, so I won't change the signatures for now, and I will change them in another PR
* MsgID
    - `Is_MsgID` is just used for an annotation to indicate that the struct is a kind of `MsgID`
* MsgResult
    - The methods are usually mere getters of struct fields
* MsgEventLog
    - `is_MsgEventLog` is just used for an annotation to indicate that the struct is a kind of `MsgEventLog`
* Prover
    - Almost all the methods usually access blockchain nodes, so I have added a `context.Context` argument
* StrategyI
    - Same as `SyncHeaders`
* ExporterConfig
    - This interface is used internally
* SignerConfig
    - Same as ChainConfig
* Signer
    - These methods can access external services, for example, in the case HSM is used
        - https://docs.web3j.io/4.8.7/advanced/HSM_transaction_signing/ is an example that uses HSM to sign a transaction

