### PR TITLE
Resolve context.TODO() and add context argument

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,6 @@ jobs:
         with:
           go-version: 1.21
         id: go
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Run Unit test
         run: make test
       - name: Build

--- a/chains/tendermint/chain.go
+++ b/chains/tendermint/chain.go
@@ -144,7 +144,7 @@ func (c *Chain) SetupForRelay(ctx context.Context) error {
 
 // LatestHeight queries the chain for the latest height and returns it
 func (c *Chain) LatestHeight(ctx context.Context) (ibcexported.Height, error) {
-	res, err := c.Client.Status(context.Background())
+	res, err := c.Client.Status(ctx)
 	if err != nil {
 		return nil, err
 	} else if res.SyncInfo.CatchingUp {
@@ -156,7 +156,7 @@ func (c *Chain) LatestHeight(ctx context.Context) (ibcexported.Height, error) {
 
 func (c *Chain) Timestamp(ctx context.Context, height ibcexported.Height) (time.Time, error) {
 	ht := int64(height.GetRevisionHeight())
-	if header, err := c.Client.Header(context.TODO(), &ht); err != nil {
+	if header, err := c.Client.Header(ctx, &ht); err != nil {
 		return time.Time{}, err
 	} else {
 		return header.Header.Time, nil

--- a/chains/tendermint/cmd/light.go
+++ b/chains/tendermint/cmd/light.go
@@ -43,7 +43,7 @@ func initLightCmd(ctx *config.Context) *cobra.Command {
 			chain := c.Chain.(*tendermint.Chain)
 			prover := c.Prover.(*tendermint.Prover)
 
-			db, df, err := prover.NewLightDB()
+			db, df, err := prover.NewLightDB(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -98,7 +98,7 @@ func updateLightCmd(ctx *config.Context) *cobra.Command {
 			}
 			prover := c.Prover.(*tendermint.Prover)
 
-			bh, err := prover.GetLatestLightHeader()
+			bh, err := prover.GetLatestLightHeader(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -136,7 +136,7 @@ func lightHeaderCmd(ctx *config.Context) *cobra.Command {
 
 			switch len(args) {
 			case 1:
-				header, err = prover.GetLatestLightHeader()
+				header, err = prover.GetLatestLightHeader(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -148,7 +148,7 @@ func lightHeaderCmd(ctx *config.Context) *cobra.Command {
 				}
 
 				if height == 0 {
-					height, err = prover.GetLatestLightHeight()
+					height, err = prover.GetLatestLightHeight(cmd.Context())
 					if err != nil {
 						return err
 					}
@@ -158,7 +158,7 @@ func lightHeaderCmd(ctx *config.Context) *cobra.Command {
 					}
 				}
 
-				header, err = prover.GetLightSignedHeaderAtHeight(height)
+				header, err = prover.GetLightSignedHeaderAtHeight(cmd.Context(), height)
 				if err != nil {
 					return err
 				}

--- a/chains/tendermint/cmd/light.go
+++ b/chains/tendermint/cmd/light.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 
@@ -65,13 +64,13 @@ func initLightCmd(ctx *config.Context) *cobra.Command {
 
 			switch {
 			case force: // force initialization from trusted node
-				_, err := prover.LightClientWithoutTrust(db)
+				_, err := prover.LightClientWithoutTrust(cmd.Context(), db)
 				if err != nil {
 					return err
 				}
 				fmt.Printf("successfully created light client for %s by trusting endpoint %s...\n", chain.ChainID(), chain.Config().RpcAddr)
 			case height > 0 && len(hash) > 0: // height and hash are given
-				_, err = prover.LightClientWithTrust(db, prover.TrustOptions(height, hash))
+				_, err = prover.LightClientWithTrust(cmd.Context(), db, prover.TrustOptions(height, hash))
 				if err != nil {
 					return wrapInitFailed(err)
 				}
@@ -104,7 +103,7 @@ func updateLightCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			ah, err := prover.UpdateLightClient(context.TODO(), 0)
+			ah, err := prover.UpdateLightClient(cmd.Context(), 0)
 			if err != nil {
 				return err
 			}
@@ -182,7 +181,7 @@ func deleteLightCmd(ctx *config.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [chain-id]",
 		Aliases: []string{"d"},
-		Short:   "wipe the light client database, forcing re-initialzation on the next run",
+		Short:   "wipe the light client database, forcing re-initialization on the next run",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := ctx.Config.GetChain(args[0])

--- a/chains/tendermint/cmd/light.go
+++ b/chains/tendermint/cmd/light.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -103,7 +104,7 @@ func updateLightCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			ah, err := prover.UpdateLightClient(0)
+			ah, err := prover.UpdateLightClient(context.TODO(), 0)
 			if err != nil {
 				return err
 			}

--- a/chains/tendermint/light.go
+++ b/chains/tendermint/light.go
@@ -84,10 +84,10 @@ func (pr *Prover) DeleteLightDB() error {
 
 // LightClientWithTrust takes a header from the chain and attempts to add that header to the light
 // database.
-func (pr *Prover) LightClientWithTrust(db dbm.DB, to light.TrustOptions) (*light.Client, error) {
+func (pr *Prover) LightClientWithTrust(ctx context.Context, db dbm.DB, to light.TrustOptions) (*light.Client, error) {
 	prov := pr.LightHTTP()
 	return light.NewClient(
-		context.Background(),
+		ctx,
 		pr.chain.config.ChainId,
 		to,
 		prov,
@@ -98,9 +98,9 @@ func (pr *Prover) LightClientWithTrust(db dbm.DB, to light.TrustOptions) (*light
 		logger)
 }
 
-// LightClientWithoutTrust querys the latest header from the chain and initializes a new light client
+// LightClientWithoutTrust queries the latest header from the chain and initializes a new light client
 // database using that header. This should only be called when first initializing the light client
-func (pr *Prover) LightClientWithoutTrust(db dbm.DB) (*light.Client, error) {
+func (pr *Prover) LightClientWithoutTrust(ctx context.Context, db dbm.DB) (*light.Client, error) {
 	var (
 		height int64
 		err    error
@@ -108,14 +108,14 @@ func (pr *Prover) LightClientWithoutTrust(db dbm.DB) (*light.Client, error) {
 	prov := pr.LightHTTP()
 
 	if err := retry.Do(func() error {
-		h, err := pr.chain.LatestHeight(context.TODO())
+		h, err := pr.chain.LatestHeight(ctx)
 		switch {
 		case err != nil:
 			return err
 		case h.GetRevisionHeight() == 0:
 			return fmt.Errorf("shouldn't be here")
 		default:
-			t, err := pr.chain.Timestamp(context.TODO(), h)
+			t, err := pr.chain.Timestamp(ctx, h)
 			if err != nil {
 				return err
 			}
@@ -125,16 +125,16 @@ func (pr *Prover) LightClientWithoutTrust(db dbm.DB) (*light.Client, error) {
 			height = int64(h.GetRevisionHeight())
 			return nil
 		}
-	}, rtyAtt, rtyDel, rtyErr); err != nil {
+	}, rtyAtt, rtyDel, rtyErr, retry.Context(ctx)); err != nil {
 		return nil, err
 	}
 
-	lb, err := prov.LightBlock(context.Background(), height)
+	lb, err := prov.LightBlock(ctx, height)
 	if err != nil {
 		return nil, err
 	}
 	return light.NewClient(
-		context.Background(),
+		ctx,
 		pr.chain.config.ChainId,
 		light.TrustOptions{
 			Period: pr.getTrustingPeriod(),

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -183,8 +183,8 @@ func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.Ch
 /* Local LightClient implementation */
 
 // GetLatestLightHeight uses the CLI utilities to pull the latest height from a given chain
-func (pr *Prover) GetLatestLightHeight() (int64, error) {
-	db, df, err := pr.NewLightDB()
+func (pr *Prover) GetLatestLightHeight(ctx context.Context) (int64, error) {
+	db, df, err := pr.NewLightDB(ctx)
 	if err != nil {
 		return -1, err
 	}
@@ -200,7 +200,7 @@ func (pr *Prover) GetLatestLightHeight() (int64, error) {
 
 func (pr *Prover) UpdateLightClient(ctx context.Context, height int64) (*tmclient.Header, error) {
 	// create database connection
-	db, df, err := pr.NewLightDB()
+	db, df, err := pr.NewLightDB(ctx)
 	if err != nil {
 		return nil, lightError(err)
 	}

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -44,7 +44,7 @@ func (pr *Prover) SetupForRelay(ctx context.Context) error {
 
 // ProveState returns the proof of an IBC state specified by `path` and `value`
 func (pr *Prover) ProveState(ctx core.QueryContext, path string, value []byte) ([]byte, clienttypes.Height, error) {
-	clientCtx := pr.chain.CLIContext(int64(ctx.Height().GetRevisionHeight()))
+	clientCtx := pr.chain.CLIContext(int64(ctx.Height().GetRevisionHeight())).WithCmdContext(ctx.Context())
 	if v, proof, proofHeight, err := ibcclient.QueryTendermintProof(clientCtx, []byte(path)); err != nil {
 		return nil, clienttypes.Height{}, err
 	} else if !bytes.Equal(v, value) {

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -132,11 +132,11 @@ func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, er
 }
 
 func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.ChainInfoICS02Querier) (bool, error) {
-	cpQueryHeight, err := counterparty.LatestHeight(context.TODO())
+	cpQueryHeight, err := counterparty.LatestHeight(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to get the latest height of the counterparty chain: %v", err)
 	}
-	cpQueryCtx := core.NewQueryContext(context.TODO(), cpQueryHeight)
+	cpQueryCtx := core.NewQueryContext(ctx, cpQueryHeight)
 
 	resCs, err := counterparty.QueryClientState(cpQueryCtx)
 	if err != nil {
@@ -159,12 +159,12 @@ func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.Ch
 	}
 	lcLastTimestamp := time.Unix(0, int64(cons.GetTimestamp()))
 
-	selfQueryHeight, err := pr.chain.LatestHeight(context.TODO())
+	selfQueryHeight, err := pr.chain.LatestHeight(ctx)
 	if err != nil {
 		return false, fmt.Errorf("failed to get the latest height of the self chain: %v", err)
 	}
 
-	selfTimestamp, err := pr.chain.Timestamp(context.TODO(), selfQueryHeight)
+	selfTimestamp, err := pr.chain.Timestamp(ctx, selfQueryHeight)
 	if err != nil {
 		return false, fmt.Errorf("failed to get timestamp of the self chain: %v", err)
 	}

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -68,12 +68,12 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height ibce
 	if height != nil {
 		tmHeight = int64(height.GetRevisionHeight())
 	}
-	selfHeader, err := pr.UpdateLightClient(context.TODO(), tmHeight)
+	selfHeader, err := pr.UpdateLightClient(ctx, tmHeight)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to update the local light client and get the header@%d: %v", tmHeight, err)
 	}
 
-	ubdPeriod, err := pr.chain.QueryUnbondingPeriod()
+	ubdPeriod, err := pr.chain.QueryUnbondingPeriod(ctx)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to query for the unbonding period: %v", err)
 	}

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -68,7 +68,7 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height ibce
 	if height != nil {
 		tmHeight = int64(height.GetRevisionHeight())
 	}
-	selfHeader, err := pr.UpdateLightClient(tmHeight)
+	selfHeader, err := pr.UpdateLightClient(context.TODO(), tmHeight)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to update the local light client and get the header@%d: %v", tmHeight, err)
 	}
@@ -128,7 +128,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 
 // GetLatestFinalizedHeader returns the latest finalized header
 func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, error) {
-	return pr.UpdateLightClient(0)
+	return pr.UpdateLightClient(ctx, 0)
 }
 
 func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.ChainInfoICS02Querier) (bool, error) {
@@ -198,7 +198,7 @@ func (pr *Prover) GetLatestLightHeight() (int64, error) {
 	return client.LastTrustedHeight()
 }
 
-func (pr *Prover) UpdateLightClient(height int64) (*tmclient.Header, error) {
+func (pr *Prover) UpdateLightClient(ctx context.Context, height int64) (*tmclient.Header, error) {
 	// create database connection
 	db, df, err := pr.NewLightDB()
 	if err != nil {
@@ -213,7 +213,7 @@ func (pr *Prover) UpdateLightClient(height int64) (*tmclient.Header, error) {
 
 	var sh *types.LightBlock
 	if height == 0 {
-		if sh, err = client.Update(context.Background(), time.Now()); err != nil {
+		if sh, err = client.Update(ctx, time.Now()); err != nil {
 			return nil, lightError(err)
 		} else if sh == nil {
 			sh, err = client.TrustedLightBlock(0)
@@ -222,7 +222,7 @@ func (pr *Prover) UpdateLightClient(height int64) (*tmclient.Header, error) {
 			}
 		}
 	} else {
-		if sh, err = client.VerifyLightBlockAtHeight(context.Background(), height, time.Now()); err != nil {
+		if sh, err = client.VerifyLightBlockAtHeight(ctx, height, time.Now()); err != nil {
 			return nil, lightError(err)
 		}
 	}

--- a/chains/tendermint/prover.go
+++ b/chains/tendermint/prover.go
@@ -96,13 +96,13 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 	tmp := latestFinalizedHeader.(*tmclient.Header)
 	h := *tmp
 
-	cph, err := counterparty.LatestHeight(context.TODO())
+	cph, err := counterparty.LatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	// retrieve the client state from the counterparty chain
-	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(context.TODO(), cph))
+	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(ctx, cph))
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +116,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 	h.TrustedHeight = cs.GetLatestHeight().(clienttypes.Height)
 
 	// query TrustedValidators at Trusted Height from the self chain
-	valSet, err := self.QueryValsetAtHeight(h.TrustedHeight)
+	valSet, err := self.QueryValsetAtHeight(ctx, h.TrustedHeight)
 	if err != nil {
 		return nil, err
 	}

--- a/chains/tendermint/query.go
+++ b/chains/tendermint/query.go
@@ -88,11 +88,11 @@ var emptyChannelRes = chantypes.NewQueryChannelResponse(
 
 // QueryChannel returns the channel associated with a channelID
 func (c *Chain) QueryChannel(ctx core.QueryContext) (chanRes *chantypes.QueryChannelResponse, err error) {
-	return c.queryChannel(int64(ctx.Height().GetRevisionHeight()), false)
+	return c.queryChannel(ctx.Context(), int64(ctx.Height().GetRevisionHeight()), false)
 }
 
-func (c *Chain) queryChannel(height int64, prove bool) (chanRes *chantypes.QueryChannelResponse, err error) {
-	res, err := chanutils.QueryChannel(c.CLIContext(height), c.PathEnd.PortID, c.PathEnd.ChannelID, prove)
+func (c *Chain) queryChannel(ctx context.Context, height int64, prove bool) (chanRes *chantypes.QueryChannelResponse, err error) {
+	res, err := chanutils.QueryChannel(c.CLIContext(height).WithCmdContext(ctx), c.PathEnd.PortID, c.PathEnd.ChannelID, prove)
 	if err != nil && strings.Contains(err.Error(), "not found") {
 		return emptyChannelRes, nil
 	} else if err != nil {

--- a/chains/tendermint/query.go
+++ b/chains/tendermint/query.go
@@ -379,12 +379,12 @@ func (c *Chain) QueryTxs(ctx context.Context, maxHeight int64, page, limit int, 
 }
 
 func (c *Chain) QueryChannelUpgrade(ctx core.QueryContext) (*chantypes.QueryUpgradeResponse, error) {
-	return c.queryChannelUpgrade(int64(ctx.Height().GetRevisionHeight()), false)
+	return c.queryChannelUpgrade(ctx.Context(), int64(ctx.Height().GetRevisionHeight()), false)
 }
 
-func (c *Chain) queryChannelUpgrade(height int64, prove bool) (chanRes *chantypes.QueryUpgradeResponse, err error) {
+func (c *Chain) queryChannelUpgrade(ctx context.Context, height int64, prove bool) (chanRes *chantypes.QueryUpgradeResponse, err error) {
 	if res, err := chanutils.QueryUpgrade(
-		c.CLIContext(height),
+		c.CLIContext(height).WithCmdContext(ctx),
 		c.PathEnd.PortID,
 		c.PathEnd.ChannelID,
 		prove,
@@ -400,12 +400,12 @@ func (c *Chain) queryChannelUpgrade(height int64, prove bool) (chanRes *chantype
 }
 
 func (c *Chain) QueryChannelUpgradeError(ctx core.QueryContext) (*chantypes.QueryUpgradeErrorResponse, error) {
-	return c.queryChannelUpgradeError(int64(ctx.Height().GetRevisionHeight()), false)
+	return c.queryChannelUpgradeError(ctx.Context(), int64(ctx.Height().GetRevisionHeight()), false)
 }
 
-func (c *Chain) queryChannelUpgradeError(height int64, prove bool) (chanRes *chantypes.QueryUpgradeErrorResponse, err error) {
+func (c *Chain) queryChannelUpgradeError(ctx context.Context, height int64, prove bool) (chanRes *chantypes.QueryUpgradeErrorResponse, err error) {
 	if res, err := chanutils.QueryUpgradeError(
-		c.CLIContext(height),
+		c.CLIContext(height).WithCmdContext(ctx),
 		c.PathEnd.PortID,
 		c.PathEnd.ChannelID,
 		prove,
@@ -421,16 +421,16 @@ func (c *Chain) queryChannelUpgradeError(height int64, prove bool) (chanRes *cha
 }
 
 func (c *Chain) QueryCanTransitionToFlushComplete(ctx core.QueryContext) (bool, error) {
-	return c.queryCanTransitionToFlushComplete(int64(ctx.Height().GetRevisionHeight()))
+	return c.queryCanTransitionToFlushComplete(ctx.Context(), int64(ctx.Height().GetRevisionHeight()))
 }
 
-func (c *Chain) queryCanTransitionToFlushComplete(height int64) (bool, error) {
-	queryClient := chantypes.NewQueryClient(c.CLIContext(height))
+func (c *Chain) queryCanTransitionToFlushComplete(ctx context.Context, height int64) (bool, error) {
+	queryClient := chantypes.NewQueryClient(c.CLIContext(height).WithCmdContext(ctx))
 	req := chantypes.QueryPacketCommitmentsRequest{
 		PortId:    c.PathEnd.PortID,
 		ChannelId: c.PathEnd.ChannelID,
 	}
-	if res, err := queryClient.PacketCommitments(context.TODO(), &req); err != nil {
+	if res, err := queryClient.PacketCommitments(ctx, &req); err != nil {
 		return false, err
 	} else {
 		return len(res.Commitments) == 0, nil

--- a/chains/tendermint/query.go
+++ b/chains/tendermint/query.go
@@ -33,11 +33,11 @@ import (
 
 // QueryClientState retrevies the latest consensus state for a client in state at a given height
 func (c *Chain) QueryClientState(ctx core.QueryContext) (*clienttypes.QueryClientStateResponse, error) {
-	return c.queryClientState(int64(ctx.Height().GetRevisionHeight()), false)
+	return c.queryClientState(ctx.Context(), int64(ctx.Height().GetRevisionHeight()), false)
 }
 
-func (c *Chain) queryClientState(height int64, _ bool) (*clienttypes.QueryClientStateResponse, error) {
-	return clientutils.QueryClientStateABCI(c.CLIContext(height), c.PathEnd.ClientID)
+func (c *Chain) queryClientState(ctx context.Context, height int64, _ bool) (*clienttypes.QueryClientStateResponse, error) {
+	return clientutils.QueryClientStateABCI(c.CLIContext(height).WithCmdContext(ctx), c.PathEnd.ClientID)
 }
 
 var emptyConnRes = conntypes.NewQueryConnectionResponse(
@@ -442,17 +442,17 @@ func (c *Chain) queryCanTransitionToFlushComplete(height int64) (bool, error) {
 /////////////////////////////////////
 
 // QueryHistoricalInfo returns historical header data
-func (c *Chain) QueryHistoricalInfo(height clienttypes.Height) (*stakingtypes.QueryHistoricalInfoResponse, error) {
+func (c *Chain) QueryHistoricalInfo(ctx context.Context, height clienttypes.Height) (*stakingtypes.QueryHistoricalInfoResponse, error) {
 	//TODO: use epoch number in query once SDK gets updated
-	qc := stakingtypes.NewQueryClient(c.CLIContext(int64(height.GetRevisionHeight())))
-	return qc.HistoricalInfo(context.Background(), &stakingtypes.QueryHistoricalInfoRequest{
+	qc := stakingtypes.NewQueryClient(c.CLIContext(int64(height.GetRevisionHeight())).WithCmdContext(ctx))
+	return qc.HistoricalInfo(ctx, &stakingtypes.QueryHistoricalInfoRequest{
 		Height: int64(height.GetRevisionHeight()),
 	})
 }
 
 // QueryValsetAtHeight returns the validator set at a given height
-func (c *Chain) QueryValsetAtHeight(height clienttypes.Height) (*tmproto.ValidatorSet, error) {
-	res, err := c.QueryHistoricalInfo(height)
+func (c *Chain) QueryValsetAtHeight(ctx context.Context, height clienttypes.Height) (*tmproto.ValidatorSet, error) {
+	res, err := c.QueryHistoricalInfo(ctx, height)
 	if err != nil {
 		return nil, err
 	}

--- a/chains/tendermint/query.go
+++ b/chains/tendermint/query.go
@@ -101,16 +101,16 @@ func (c *Chain) queryChannel(height int64, prove bool) (chanRes *chantypes.Query
 	return res, nil
 }
 
-// QueryClientConsensusState retrevies the latest consensus state for a client in state at a given height
+// QueryClientConsensusState retrieves the latest consensus state for a client in state at a given height
 func (c *Chain) QueryClientConsensusState(
 	ctx core.QueryContext, dstClientConsHeight ibcexported.Height) (*clienttypes.QueryConsensusStateResponse, error) {
-	return c.queryClientConsensusState(int64(ctx.Height().GetRevisionHeight()), dstClientConsHeight, false)
+	return c.queryClientConsensusState(ctx.Context(), int64(ctx.Height().GetRevisionHeight()), dstClientConsHeight, false)
 }
 
 func (c *Chain) queryClientConsensusState(
-	height int64, dstClientConsHeight ibcexported.Height, _ bool) (*clienttypes.QueryConsensusStateResponse, error) {
+	ctx context.Context, height int64, dstClientConsHeight ibcexported.Height, _ bool) (*clienttypes.QueryConsensusStateResponse, error) {
 	return clientutils.QueryConsensusStateABCI(
-		c.CLIContext(height),
+		c.CLIContext(height).WithCmdContext(ctx),
 		c.PathEnd.ClientID,
 		dstClientConsHeight,
 	)

--- a/chains/tendermint/query.go
+++ b/chains/tendermint/query.go
@@ -503,12 +503,12 @@ func (c *Chain) toTmValidator(val stakingtypes.Validator) (*tmtypes.Validator, e
 }
 
 // QueryUnbondingPeriod returns the unbonding period of the chain
-func (c *Chain) QueryUnbondingPeriod() (time.Duration, error) {
+func (c *Chain) QueryUnbondingPeriod(ctx context.Context) (time.Duration, error) {
 	req := stakingtypes.QueryParamsRequest{}
 
-	queryClient := stakingtypes.NewQueryClient(c.CLIContext(0))
+	queryClient := stakingtypes.NewQueryClient(c.CLIContext(0).WithCmdContext(ctx))
 
-	res, err := queryClient.Params(context.Background(), &req)
+	res, err := queryClient.Params(ctx, &req)
 	if err != nil {
 		return 0, err
 	}

--- a/chains/tendermint/query.go
+++ b/chains/tendermint/query.go
@@ -58,11 +58,11 @@ var emptyConnRes = conntypes.NewQueryConnectionResponse(
 
 // QueryConnection returns the remote end of a given connection
 func (c *Chain) QueryConnection(ctx core.QueryContext, connectionID string) (*conntypes.QueryConnectionResponse, error) {
-	return c.queryConnection(int64(ctx.Height().GetRevisionHeight()), connectionID, false)
+	return c.queryConnection(ctx.Context(), int64(ctx.Height().GetRevisionHeight()), connectionID, false)
 }
 
-func (c *Chain) queryConnection(height int64, connectionID string, prove bool) (*conntypes.QueryConnectionResponse, error) {
-	res, err := connutils.QueryConnection(c.CLIContext(height), connectionID, prove)
+func (c *Chain) queryConnection(ctx context.Context, height int64, connectionID string, prove bool) (*conntypes.QueryConnectionResponse, error) {
+	res, err := connutils.QueryConnection(c.CLIContext(height).WithCmdContext(ctx), connectionID, prove)
 	if err != nil && strings.Contains(err.Error(), "not found") {
 		return emptyConnRes, nil
 	} else if err != nil {

--- a/chains/tendermint/query.go
+++ b/chains/tendermint/query.go
@@ -125,9 +125,9 @@ func (c *Chain) QueryBalance(ctx core.QueryContext, addr sdk.AccAddress) (sdk.Co
 		CountTotal: true,
 	}, true)
 
-	queryClient := bankTypes.NewQueryClient(c.CLIContext(0))
+	queryClient := bankTypes.NewQueryClient(c.CLIContext(0).WithCmdContext(ctx.Context()))
 
-	res, err := queryClient.AllBalances(context.Background(), params)
+	res, err := queryClient.AllBalances(ctx.Context(), params)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +137,7 @@ func (c *Chain) QueryBalance(ctx core.QueryContext, addr sdk.AccAddress) (sdk.Co
 
 // QueryDenomTraces returns all the denom traces from a given chain
 func (c *Chain) QueryDenomTraces(ctx core.QueryContext, offset, limit uint64) (*transfertypes.QueryDenomTracesResponse, error) {
-	return transfertypes.NewQueryClient(c.CLIContext(int64(ctx.Height().GetRevisionHeight()))).DenomTraces(context.Background(), &transfertypes.QueryDenomTracesRequest{
+	return transfertypes.NewQueryClient(c.CLIContext(int64(ctx.Height().GetRevisionHeight())).WithCmdContext(ctx.Context())).DenomTraces(ctx.Context(), &transfertypes.QueryDenomTracesRequest{
 		Pagination: &querytypes.PageRequest{
 			Key:        []byte(""),
 			Offset:     offset,

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -252,7 +252,7 @@ func queryUnrelayedPackets(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sh, err := core.NewSyncHeaders(c[src], c[dst])
+			sh, err := core.NewSyncHeaders(context.TODO(), c[src], c[dst])
 			if err != nil {
 				return err
 			}
@@ -300,7 +300,7 @@ func queryUnrelayedAcknowledgements(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sh, err := core.NewSyncHeaders(c[src], c[dst])
+			sh, err := core.NewSyncHeaders(context.TODO(), c[src], c[dst])
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 
@@ -56,12 +55,12 @@ func queryClientCmd(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			latestHeight, err := c.LatestHeight(context.TODO())
+			latestHeight, err := c.LatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
 			queryHeight := clienttypes.NewHeight(latestHeight.GetRevisionNumber(), uint64(height))
-			res, err := c.QueryClientState(core.NewQueryContext(context.TODO(), queryHeight))
+			res, err := c.QueryClientState(core.NewQueryContext(cmd.Context(), queryHeight))
 			if err != nil {
 				return err
 			}
@@ -98,12 +97,12 @@ func queryConnection(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			latestHeight, err := c.LatestHeight(context.TODO())
+			latestHeight, err := c.LatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
 			queryHeight := clienttypes.NewHeight(latestHeight.GetRevisionNumber(), uint64(height))
-			res, err := c.QueryConnection(core.NewQueryContext(context.TODO(), queryHeight), c.Path().ConnectionID)
+			res, err := c.QueryConnection(core.NewQueryContext(cmd.Context(), queryHeight), c.Path().ConnectionID)
 			if err != nil {
 				return err
 			}
@@ -136,12 +135,12 @@ func queryChannel(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			latestHeight, err := c.LatestHeight(context.TODO())
+			latestHeight, err := c.LatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
 			queryHeight := clienttypes.NewHeight(latestHeight.GetRevisionNumber(), uint64(height))
-			res, err := c.QueryChannel(core.NewQueryContext(context.TODO(), queryHeight))
+			res, err := c.QueryChannel(core.NewQueryContext(cmd.Context(), queryHeight))
 			if err != nil {
 				return err
 			}
@@ -175,12 +174,12 @@ func queryChannelUpgrade(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			latestHeight, err := c.LatestHeight(context.TODO())
+			latestHeight, err := c.LatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
 			queryHeight := clienttypes.NewHeight(latestHeight.GetRevisionNumber(), uint64(height))
-			res, err := c.QueryChannelUpgrade(core.NewQueryContext(context.TODO(), queryHeight))
+			res, err := c.QueryChannelUpgrade(core.NewQueryContext(cmd.Context(), queryHeight))
 			if err != nil {
 				return err
 			} else if res == nil {
@@ -221,12 +220,12 @@ func queryBalanceCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			h, err := chain.LatestHeight(context.TODO())
+			h, err := chain.LatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
 
-			coins, err := helpers.QueryBalance(chain, h, addr, showDenoms)
+			coins, err := helpers.QueryBalance(cmd.Context(), chain, h, addr, showDenoms)
 			if err != nil {
 				return err
 			}
@@ -252,7 +251,7 @@ func queryUnrelayedPackets(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sh, err := core.NewSyncHeaders(context.TODO(), c[src], c[dst])
+			sh, err := core.NewSyncHeaders(cmd.Context(), c[src], c[dst])
 			if err != nil {
 				return err
 			}
@@ -260,7 +259,7 @@ func queryUnrelayedPackets(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sp, err := st.UnrelayedPackets(context.TODO(), c[src], c[dst], sh, true)
+			sp, err := st.UnrelayedPackets(cmd.Context(), c[src], c[dst], sh, true)
 			if err != nil {
 				return err
 			}
@@ -300,7 +299,7 @@ func queryUnrelayedAcknowledgements(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sh, err := core.NewSyncHeaders(context.TODO(), c[src], c[dst])
+			sh, err := core.NewSyncHeaders(cmd.Context(), c[src], c[dst])
 			if err != nil {
 				return err
 			}
@@ -309,7 +308,7 @@ func queryUnrelayedAcknowledgements(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			sp, err := st.UnrelayedAcknowledgements(context.TODO(), c[src], c[dst], sh, true)
+			sp, err := st.UnrelayedAcknowledgements(cmd.Context(), c[src], c[dst], sh, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -260,7 +260,7 @@ func queryUnrelayedPackets(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sp, err := st.UnrelayedPackets(c[src], c[dst], sh, true)
+			sp, err := st.UnrelayedPackets(context.TODO(), c[src], c[dst], sh, true)
 			if err != nil {
 				return err
 			}
@@ -309,7 +309,7 @@ func queryUnrelayedAcknowledgements(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			sp, err := st.UnrelayedAcknowledgements(c[src], c[dst], sh, true)
+			sp, err := st.UnrelayedAcknowledgements(context.TODO(), c[src], c[dst], sh, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -63,11 +62,11 @@ func startCmd(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := st.SetupRelay(context.TODO(), c[src], c[dst]); err != nil {
+			if err := st.SetupRelay(cmd.Context(), c[src], c[dst]); err != nil {
 				return err
 			}
 			return core.StartService(
-				context.Background(),
+				cmd.Context(),
 				st,
 				c[src],
 				c[dst],

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -194,7 +194,7 @@ func createChannelCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			return core.CreateChannel(pathName, c[src], c[dst], to)
+			return core.CreateChannel(cmd.Context(), pathName, c[src], c[dst], to)
 		},
 	}
 

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -464,7 +464,7 @@ func relayMsgsCmd(ctx *config.Context) *cobra.Command {
 			doExecuteAckSrc := false
 			doExecuteAckDst := false
 
-			if m, err := st.UpdateClients(c[src], c[dst], doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst, sh, viper.GetBool(flagDoRefresh)); err != nil {
+			if m, err := st.UpdateClients(context.TODO(), c[src], c[dst], doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst, sh, viper.GetBool(flagDoRefresh)); err != nil {
 				return err
 			} else {
 				msgs.Merge(m)
@@ -539,7 +539,7 @@ func relayAcksCmd(ctx *config.Context) *cobra.Command {
 			doExecuteAckSrc := len(sp.Dst) > 0
 			doExecuteAckDst := len(sp.Src) > 0
 
-			if m, err := st.UpdateClients(c[src], c[dst], doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst, sh, viper.GetBool(flagDoRefresh)); err != nil {
+			if m, err := st.UpdateClients(context.TODO(), c[src], c[dst], doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst, sh, viper.GetBool(flagDoRefresh)); err != nil {
 				return err
 			} else {
 				msgs.Merge(m)

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -470,7 +470,7 @@ func relayMsgsCmd(ctx *config.Context) *cobra.Command {
 				msgs.Merge(m)
 			}
 
-			if m, err := st.RelayPackets(c[src], c[dst], sp, sh, doExecuteRelaySrc, doExecuteRelayDst); err != nil {
+			if m, err := st.RelayPackets(context.TODO(), c[src], c[dst], sp, sh, doExecuteRelaySrc, doExecuteRelayDst); err != nil {
 				return err
 			} else {
 				msgs.Merge(m)
@@ -545,7 +545,7 @@ func relayAcksCmd(ctx *config.Context) *cobra.Command {
 				msgs.Merge(m)
 			}
 
-			if m, err := st.RelayAcknowledgements(c[src], c[dst], sp, sh, doExecuteAckSrc, doExecuteAckDst); err != nil {
+			if m, err := st.RelayAcknowledgements(context.TODO(), c[src], c[dst], sp, sh, doExecuteAckSrc, doExecuteAckDst); err != nil {
 				return err
 			} else {
 				msgs.Merge(m)

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -447,7 +447,7 @@ func relayMsgsCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			sp, err := st.UnrelayedPackets(c[src], c[dst], sh, false)
+			sp, err := st.UnrelayedPackets(context.TODO(), c[src], c[dst], sh, false)
 			if err != nil {
 				return err
 			}
@@ -522,7 +522,7 @@ func relayAcksCmd(ctx *config.Context) *cobra.Command {
 
 			// sp.Src contains all sequences acked on SRC but acknowledgement not processed on DST
 			// sp.Dst contains all sequences acked on DST but acknowledgement not processed on SRC
-			sp, err := st.UnrelayedAcknowledgements(c[src], c[dst], sh, false)
+			sp, err := st.UnrelayedAcknowledgements(context.TODO(), c[src], c[dst], sh, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -160,7 +160,7 @@ func createConnectionCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			return core.CreateConnection(pathName, c[src], c[dst], to)
+			return core.CreateConnection(cmd.Context(), pathName, c[src], c[dst], to)
 		},
 	}
 

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -476,7 +476,7 @@ func relayMsgsCmd(ctx *config.Context) *cobra.Command {
 				msgs.Merge(m)
 			}
 
-			st.Send(c[src], c[dst], msgs)
+			st.Send(context.TODO(), c[src], c[dst], msgs)
 
 			return nil
 		},
@@ -551,7 +551,7 @@ func relayAcksCmd(ctx *config.Context) *cobra.Command {
 				msgs.Merge(m)
 			}
 
-			st.Send(c[src], c[dst], msgs)
+			st.Send(context.TODO(), c[src], c[dst], msgs)
 
 			return nil
 		},

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -279,6 +279,7 @@ func channelUpgradeInitCmd(ctx *config.Context) *cobra.Command {
 			}
 
 			return core.InitChannelUpgrade(
+				cmd.Context(),
 				chain,
 				cp,
 				chantypes.UpgradeFields{
@@ -347,7 +348,7 @@ func channelUpgradeExecuteCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			return core.ExecuteChannelUpgrade(pathName, src, dst, interval, targetSrcState, targetDstState)
+			return core.ExecuteChannelUpgrade(cmd.Context(), pathName, src, dst, interval, targetSrcState, targetDstState)
 		},
 	}
 
@@ -401,7 +402,7 @@ func channelUpgradeCancelCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 
-			return core.CancelChannelUpgrade(chain, cp, settlementInterval)
+			return core.CancelChannelUpgrade(cmd.Context(), chain, cp, settlementInterval)
 		},
 	}
 

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -434,7 +434,7 @@ func relayMsgsCmd(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sh, err := core.NewSyncHeaders(c[src], c[dst])
+			sh, err := core.NewSyncHeaders(context.TODO(), c[src], c[dst])
 			if err != nil {
 				return err
 			}
@@ -511,7 +511,7 @@ func relayAcksCmd(ctx *config.Context) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sh, err := core.NewSyncHeaders(c[src], c[dst])
+			sh, err := core.NewSyncHeaders(context.TODO(), c[src], c[dst])
 			if err != nil {
 				return err
 			}

--- a/cmd/xfer.go
+++ b/cmd/xfer.go
@@ -64,11 +64,11 @@ func xfersend(ctx *config.Context) *cobra.Command {
 			case toHeightOffset > 0 && toTimeOffset > 0:
 				return fmt.Errorf("cannot set both --timeout-height-offset and --timeout-time-offset, choose one")
 			case toHeightOffset > 0:
-				return core.SendTransferMsg(c[src], c[dst], amount, dstAddr, toHeightOffset, 0)
+				return core.SendTransferMsg(cmd.Context(), c[src], c[dst], amount, dstAddr, toHeightOffset, 0)
 			case toTimeOffset > 0:
-				return core.SendTransferMsg(c[src], c[dst], amount, dstAddr, 0, toTimeOffset)
+				return core.SendTransferMsg(cmd.Context(), c[src], c[dst], amount, dstAddr, 0, toTimeOffset)
 			case toHeightOffset == 0 && toTimeOffset == 0:
-				return core.SendTransferMsg(c[src], c[dst], amount, dstAddr, 0, 0)
+				return core.SendTransferMsg(cmd.Context(), c[src], c[dst], amount, dstAddr, 0, 0)
 			default:
 				return fmt.Errorf("shouldn't be here")
 			}

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -164,7 +164,7 @@ func ExecuteChannelUpgrade(pathName string, src, dst *ProvableChain, interval ti
 		steps.Send(context.TODO(), src, dst)
 
 		if steps.Success() {
-			if err := SyncChainConfigsFromEvents(pathName, steps.SrcMsgIDs, steps.DstMsgIDs, src, dst); err != nil {
+			if err := SyncChainConfigsFromEvents(context.TODO(), pathName, steps.SrcMsgIDs, steps.DstMsgIDs, src, dst); err != nil {
 				logger.Error("failed to synchronize the updated path config to the config file", err)
 				return err
 			}

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -197,8 +197,8 @@ func CancelChannelUpgrade(chain, cp *ProvableChain, settlementInterval time.Dura
 			logger.Error("failed to create a SyncHeaders", err)
 			return err
 		}
-		ctx := sh.GetQueryContext(chain.ChainID())
-		cpCtx := sh.GetQueryContext(cp.ChainID())
+		ctx := sh.GetQueryContext(context.TODO(), chain.ChainID())
+		cpCtx := sh.GetQueryContext(context.TODO(), cp.ChainID())
 
 		chann, _, settled, err := querySettledChannelPair(ctx, cpCtx, chain, cp, false)
 		if err != nil {
@@ -320,8 +320,8 @@ func upgradeChannelStep(src, dst *ProvableChain, targetSrcState, targetDstState 
 		return nil, err
 	}
 
-	srcCtx := sh.GetQueryContext(src.ChainID())
-	dstCtx := sh.GetQueryContext(dst.ChainID())
+	srcCtx := sh.GetQueryContext(context.TODO(), src.ChainID())
+	dstCtx := sh.GetQueryContext(context.TODO(), dst.ChainID())
 
 	// query finalized channels with proofs
 	srcChan, dstChan, settled, err := querySettledChannelPair(srcCtx, dstCtx, src, dst, true)

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -192,7 +192,7 @@ func CancelChannelUpgrade(chain, cp *ProvableChain, settlementInterval time.Dura
 	defer ticker.Stop()
 
 	for {
-		sh, err := NewSyncHeaders(chain, cp)
+		sh, err := NewSyncHeaders(context.TODO(), chain, cp)
 		if err != nil {
 			logger.Error("failed to create a SyncHeaders", err)
 			return err
@@ -300,7 +300,7 @@ func upgradeChannelStep(src, dst *ProvableChain, targetSrcState, targetDstState 
 	out := NewRelayMsgs()
 
 	// First, update the light clients to the latest header and return the header
-	sh, err := NewSyncHeaders(src, dst)
+	sh, err := NewSyncHeaders(context.TODO(), src, dst)
 	if err != nil {
 		logger.Error("failed to create SyncHeaders", err)
 		return nil, err

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -161,7 +161,7 @@ func ExecuteChannelUpgrade(pathName string, src, dst *ProvableChain, interval ti
 			continue
 		}
 
-		steps.Send(src, dst)
+		steps.Send(context.TODO(), src, dst)
 
 		if steps.Success() {
 			if err := SyncChainConfigsFromEvents(pathName, steps.SrcMsgIDs, steps.DstMsgIDs, src, dst); err != nil {

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -309,7 +309,7 @@ func upgradeChannelStep(src, dst *ProvableChain, targetSrcState, targetDstState 
 	// Query a number of things all at once
 	var srcUpdateHeaders, dstUpdateHeaders []Header
 	if err := retry.Do(func() error {
-		srcUpdateHeaders, dstUpdateHeaders, err = sh.SetupBothHeadersForUpdate(src, dst)
+		srcUpdateHeaders, dstUpdateHeaders, err = sh.SetupBothHeadersForUpdate(context.TODO(), src, dst)
 		return err
 	}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(uint, error) {
 		if err := sh.Updates(context.TODO(), src, dst); err != nil {

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -312,7 +312,7 @@ func upgradeChannelStep(src, dst *ProvableChain, targetSrcState, targetDstState 
 		srcUpdateHeaders, dstUpdateHeaders, err = sh.SetupBothHeadersForUpdate(src, dst)
 		return err
 	}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(uint, error) {
-		if err := sh.Updates(src, dst); err != nil {
+		if err := sh.Updates(context.TODO(), src, dst); err != nil {
 			panic(err)
 		}
 	})); err != nil {

--- a/core/channel.go
+++ b/core/channel.go
@@ -67,7 +67,9 @@ func CreateChannel(ctx context.Context, pathName string, src, dst *ProvableChain
 			}
 
 			logger.Warn("Retrying transaction...")
-			time.Sleep(5 * time.Second)
+			if err := wait(ctx, 5*time.Second); err != nil {
+				return err
+			}
 		}
 
 		select {

--- a/core/channel.go
+++ b/core/channel.go
@@ -139,7 +139,7 @@ func createChannelStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 	)
 
 	err = retry.Do(func() error {
-		srcUpdateHeaders, dstUpdateHeaders, err = sh.SetupBothHeadersForUpdate(src, dst)
+		srcUpdateHeaders, dstUpdateHeaders, err = sh.SetupBothHeadersForUpdate(context.TODO(), src, dst)
 		return err
 	}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(n uint, err error) {
 		// logRetryUpdateHeaders(src, dst, n, err)

--- a/core/channel.go
+++ b/core/channel.go
@@ -45,7 +45,7 @@ func CreateChannel(pathName string, src, dst *ProvableChain, to time.Duration) e
 
 		if chanSteps.Success() {
 			// In the case of success, synchronize the config file from generated channel identifiers
-			if err := SyncChainConfigsFromEvents(pathName, chanSteps.SrcMsgIDs, chanSteps.DstMsgIDs, src, dst); err != nil {
+			if err := SyncChainConfigsFromEvents(context.TODO(), pathName, chanSteps.SrcMsgIDs, chanSteps.DstMsgIDs, src, dst); err != nil {
 				return err
 			}
 

--- a/core/channel.go
+++ b/core/channel.go
@@ -143,7 +143,7 @@ func createChannelStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		return err
 	}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(n uint, err error) {
 		// logRetryUpdateHeaders(src, dst, n, err)
-		if err := sh.Updates(src, dst); err != nil {
+		if err := sh.Updates(context.TODO(), src, dst); err != nil {
 			panic(err)
 		}
 	}))

--- a/core/channel.go
+++ b/core/channel.go
@@ -41,7 +41,7 @@ func CreateChannel(pathName string, src, dst *ProvableChain, to time.Duration) e
 			continue
 		}
 
-		chanSteps.Send(src, dst)
+		chanSteps.Send(context.TODO(), src, dst)
 
 		if chanSteps.Success() {
 			// In the case of success, synchronize the config file from generated channel identifiers

--- a/core/channel.go
+++ b/core/channel.go
@@ -128,7 +128,7 @@ func createChannelStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		return nil, err
 	}
 	// First, update the light clients to the latest header and return the header
-	sh, err := NewSyncHeaders(src, dst)
+	sh, err := NewSyncHeaders(context.TODO(), src, dst)
 	if err != nil {
 		return nil, err
 	}

--- a/core/channel.go
+++ b/core/channel.go
@@ -152,8 +152,8 @@ func createChannelStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 	}
 
 	srcChan, dstChan, settled, err := querySettledChannelPair(
-		sh.GetQueryContext(src.ChainID()),
-		sh.GetQueryContext(dst.ChainID()),
+		sh.GetQueryContext(context.TODO(), src.ChainID()),
+		sh.GetQueryContext(context.TODO(), dst.ChainID()),
 		src,
 		dst,
 		true,

--- a/core/client.go
+++ b/core/client.go
@@ -123,7 +123,7 @@ func CreateClients(pathName string, src, dst *ProvableChain, srcHeight, dstHeigh
 	// Send msgs to both chains
 	if clients.Ready() {
 		// TODO: Add retry here for out of gas or other errors
-		clients.Send(src, dst)
+		clients.Send(context.TODO(), src, dst)
 		if clients.Success() {
 			logger.Info(
 				"★ Clients created",
@@ -167,7 +167,7 @@ func UpdateClients(src, dst *ProvableChain) error {
 	}
 	// Send msgs to both chains
 	if clients.Ready() {
-		if clients.Send(src, dst); clients.Success() {
+		if clients.Send(context.TODO(), src, dst); clients.Success() {
 			logger.Info(
 				"★ Clients updated",
 			)

--- a/core/client.go
+++ b/core/client.go
@@ -143,7 +143,7 @@ func UpdateClients(src, dst *ProvableChain) error {
 		clients = &RelayMsgs{Src: []sdk.Msg{}, Dst: []sdk.Msg{}}
 	)
 	// First, update the light clients to the latest header and return the header
-	sh, err := NewSyncHeaders(src, dst)
+	sh, err := NewSyncHeaders(context.TODO(), src, dst)
 	if err != nil {
 		logger.Error(
 			"failed to create sync headers for update client",

--- a/core/client.go
+++ b/core/client.go
@@ -151,7 +151,7 @@ func UpdateClients(src, dst *ProvableChain) error {
 		)
 		return err
 	}
-	srcUpdateHeaders, dstUpdateHeaders, err := sh.SetupBothHeadersForUpdate(src, dst)
+	srcUpdateHeaders, dstUpdateHeaders, err := sh.SetupBothHeadersForUpdate(context.TODO(), src, dst)
 	if err != nil {
 		logger.Error(
 			"failed to setup both headers for update client",

--- a/core/client.go
+++ b/core/client.go
@@ -128,7 +128,7 @@ func CreateClients(pathName string, src, dst *ProvableChain, srcHeight, dstHeigh
 			logger.Info(
 				"★ Clients created",
 			)
-			if err := SyncChainConfigsFromEvents(pathName, clients.SrcMsgIDs, clients.DstMsgIDs, src, dst); err != nil {
+			if err := SyncChainConfigsFromEvents(context.TODO(), pathName, clients.SrcMsgIDs, clients.DstMsgIDs, src, dst); err != nil {
 				return err
 			}
 		}

--- a/core/config.go
+++ b/core/config.go
@@ -137,22 +137,22 @@ func (cc ChainProverConfig) Build() (*ProvableChain, error) {
 	return NewProvableChain(chain, prover), nil
 }
 
-func SyncChainConfigsFromEvents(pathName string, msgIDsSrc, msgIDsDst []MsgID, src, dst *ProvableChain) error {
-	if err := SyncChainConfigFromEvents(pathName, msgIDsSrc, src); err != nil {
+func SyncChainConfigsFromEvents(ctx context.Context, pathName string, msgIDsSrc, msgIDsDst []MsgID, src, dst *ProvableChain) error {
+	if err := SyncChainConfigFromEvents(ctx, pathName, msgIDsSrc, src); err != nil {
 		return err
 	}
-	if err := SyncChainConfigFromEvents(pathName, msgIDsDst, dst); err != nil {
+	if err := SyncChainConfigFromEvents(ctx, pathName, msgIDsDst, dst); err != nil {
 		return err
 	}
 	return nil
 }
 
-func SyncChainConfigFromEvents(pathName string, msgIDs []MsgID, chain *ProvableChain) error {
+func SyncChainConfigFromEvents(ctx context.Context, pathName string, msgIDs []MsgID, chain *ProvableChain) error {
 	for _, msgID := range msgIDs {
 		if msgID == nil {
 			continue
 		}
-		msgRes, err := chain.Chain.GetMsgResult(context.TODO(), msgID)
+		msgRes, err := chain.Chain.GetMsgResult(ctx, msgID)
 		if err != nil {
 			return fmt.Errorf("failed to get message result: %v", err)
 		} else if ok, failureReason := msgRes.Status(); !ok {
@@ -170,7 +170,7 @@ func SyncChainConfigFromEvents(pathName string, msgIDs []MsgID, chain *ProvableC
 			case *EventGenerateChannelIdentifier:
 				kv[PathConfigChannelID] = event.ID
 			case *EventUpgradeChannel:
-				chann, err := chain.QueryChannel(NewQueryContext(context.TODO(), msgRes.BlockHeight()))
+				chann, err := chain.QueryChannel(NewQueryContext(ctx, msgRes.BlockHeight()))
 				if err != nil {
 					return fmt.Errorf("failed to query a channel corresponding to the EventUpgradeChannel event: %v", err)
 				}

--- a/core/connection.go
+++ b/core/connection.go
@@ -75,7 +75,9 @@ func CreateConnection(ctx context.Context, pathName string, src, dst *ProvableCh
 			}
 
 			logger.Warn("Retrying transaction...")
-			time.Sleep(5 * time.Second)
+			if err := wait(ctx, 5*time.Second); err != nil {
+				return err
+			}
 		}
 
 		select {

--- a/core/connection.go
+++ b/core/connection.go
@@ -156,7 +156,7 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		return err
 	}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(n uint, err error) {
 		// logRetryUpdateHeaders(src, dst, n, err)
-		if err := sh.Updates(src, dst); err != nil {
+		if err := sh.Updates(context.TODO(), src, dst); err != nil {
 			panic(err)
 		}
 	}))

--- a/core/connection.go
+++ b/core/connection.go
@@ -152,7 +152,7 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		srcHostConsProof, dstHostConsProof []byte
 	)
 	err = retry.Do(func() error {
-		srcUpdateHeaders, dstUpdateHeaders, err = sh.SetupBothHeadersForUpdate(src, dst)
+		srcUpdateHeaders, dstUpdateHeaders, err = sh.SetupBothHeadersForUpdate(context.TODO(), src, dst)
 		return err
 	}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(n uint, err error) {
 		// logRetryUpdateHeaders(src, dst, n, err)

--- a/core/connection.go
+++ b/core/connection.go
@@ -49,7 +49,7 @@ func CreateConnection(pathName string, src, dst *ProvableChain, to time.Duration
 			continue
 		}
 
-		connSteps.Send(src, dst)
+		connSteps.Send(context.TODO(), src, dst)
 
 		if connSteps.Success() {
 			// In the case of success, synchronize the config file from generated connection identifiers.

--- a/core/connection.go
+++ b/core/connection.go
@@ -165,8 +165,8 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 	}
 
 	srcConn, dstConn, settled, err := querySettledConnectionPair(
-		sh.GetQueryContext(src.ChainID()),
-		sh.GetQueryContext(dst.ChainID()),
+		sh.GetQueryContext(context.TODO(), src.ChainID()),
+		sh.GetQueryContext(context.TODO(), dst.ChainID()),
 		src,
 		dst,
 		true,
@@ -179,7 +179,7 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 
 	if !(srcConn.Connection.State == conntypes.UNINITIALIZED && dstConn.Connection.State == conntypes.UNINITIALIZED) {
 		// Query client state from each chain's client
-		srcCsRes, dstCsRes, err = QueryClientStatePair(sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()), src, dst, true)
+		srcCsRes, dstCsRes, err = QueryClientStatePair(sh.GetQueryContext(context.TODO(), src.ChainID()), sh.GetQueryContext(context.TODO(), dst.ChainID()), src, dst, true)
 		if err != nil {
 			return nil, err
 		}
@@ -193,7 +193,7 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		// Store the heights
 		srcConsH, dstConsH = srcCS.GetLatestHeight(), dstCS.GetLatestHeight()
 		srcConsRes, dstConsRes, err = QueryClientConsensusStatePair(
-			sh.GetQueryContext(src.ChainID()), sh.GetQueryContext(dst.ChainID()),
+			sh.GetQueryContext(context.TODO(), src.ChainID()), sh.GetQueryContext(context.TODO(), dst.ChainID()),
 			src, dst, srcConsH, dstConsH, true)
 		if err != nil {
 			return nil, err
@@ -204,11 +204,11 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		if err := dst.Codec().UnpackAny(dstConsRes.ConsensusState, &dstCons); err != nil {
 			return nil, err
 		}
-		srcHostConsProof, err = src.ProveHostConsensusState(sh.GetQueryContext(src.ChainID()), dstCS.GetLatestHeight(), dstCons)
+		srcHostConsProof, err = src.ProveHostConsensusState(sh.GetQueryContext(context.TODO(), src.ChainID()), dstCS.GetLatestHeight(), dstCons)
 		if err != nil {
 			return nil, err
 		}
-		dstHostConsProof, err = dst.ProveHostConsensusState(sh.GetQueryContext(dst.ChainID()), srcCS.GetLatestHeight(), srcCons)
+		dstHostConsProof, err = dst.ProveHostConsensusState(sh.GetQueryContext(context.TODO(), dst.ChainID()), srcCS.GetLatestHeight(), srcCons)
 		if err != nil {
 			return nil, err
 		}

--- a/core/connection.go
+++ b/core/connection.go
@@ -137,7 +137,7 @@ func createConnectionStep(src, dst *ProvableChain) (*RelayMsgs, error) {
 		return nil, err
 	}
 	// First, update the light clients to the latest header and return the header
-	sh, err := NewSyncHeaders(src, dst)
+	sh, err := NewSyncHeaders(context.TODO(), src, dst)
 	if err != nil {
 		return nil, err
 	}

--- a/core/connection.go
+++ b/core/connection.go
@@ -53,7 +53,7 @@ func CreateConnection(pathName string, src, dst *ProvableChain, to time.Duration
 
 		if connSteps.Success() {
 			// In the case of success, synchronize the config file from generated connection identifiers.
-			if err := SyncChainConfigsFromEvents(pathName, connSteps.SrcMsgIDs, connSteps.DstMsgIDs, src, dst); err != nil {
+			if err := SyncChainConfigsFromEvents(context.TODO(), pathName, connSteps.SrcMsgIDs, connSteps.DstMsgIDs, src, dst); err != nil {
 				return err
 			}
 

--- a/core/headers.go
+++ b/core/headers.go
@@ -30,7 +30,7 @@ type SyncHeaders interface {
 	SetupHeadersForUpdate(ctx context.Context, src, dst ChainLightClient) ([]Header, error)
 
 	// SetupBothHeadersForUpdate returns both `src` and `dst` chain's headers needed to update the clients on each chain
-	SetupBothHeadersForUpdate(src, dst ChainLightClient) (srcHeaders []Header, dstHeaders []Header, err error)
+	SetupBothHeadersForUpdate(ctx context.Context, src, dst ChainLightClient) (srcHeaders, dstHeaders []Header, err error)
 }
 
 // ChainInfoLightClient = ChainInfo + LightClient
@@ -132,14 +132,14 @@ func (sh syncHeaders) SetupHeadersForUpdate(ctx context.Context, src, dst ChainL
 }
 
 // SetupBothHeadersForUpdate returns both `src` and `dst` chain's headers to update the clients on each chain
-func (sh syncHeaders) SetupBothHeadersForUpdate(src, dst ChainLightClient) ([]Header, []Header, error) {
+func (sh syncHeaders) SetupBothHeadersForUpdate(ctx context.Context, src, dst ChainLightClient) ([]Header, []Header, error) {
 	logger := GetChainPairLogger(src, dst)
-	srcHs, err := sh.SetupHeadersForUpdate(context.TODO(), src, dst)
+	srcHs, err := sh.SetupHeadersForUpdate(ctx, src, dst)
 	if err != nil {
 		logger.Error("error setting up headers for update on src", err)
 		return nil, nil, err
 	}
-	dstHs, err := sh.SetupHeadersForUpdate(context.TODO(), dst, src)
+	dstHs, err := sh.SetupHeadersForUpdate(ctx, dst, src)
 	if err != nil {
 		logger.Error("error setting up headers for update on dst", err)
 		return nil, nil, err

--- a/core/headers.go
+++ b/core/headers.go
@@ -24,7 +24,7 @@ type SyncHeaders interface {
 	GetLatestFinalizedHeader(chainID string) Header
 
 	// GetQueryContext builds a query context based on the latest finalized header
-	GetQueryContext(chainID string) QueryContext
+	GetQueryContext(ctx context.Context, chainID string) QueryContext
 
 	// SetupHeadersForUpdate returns `src` chain's headers needed to update the client on `dst` chain
 	SetupHeadersForUpdate(ctx context.Context, src, dst ChainLightClient) ([]Header, error)
@@ -117,8 +117,8 @@ func (sh syncHeaders) GetLatestFinalizedHeader(chainID string) Header {
 }
 
 // GetQueryContext builds a query context based on the latest finalized header
-func (sh syncHeaders) GetQueryContext(chainID string) QueryContext {
-	return NewQueryContext(context.TODO(), sh.GetLatestFinalizedHeader(chainID).GetHeight())
+func (sh syncHeaders) GetQueryContext(ctx context.Context, chainID string) QueryContext {
+	return NewQueryContext(ctx, sh.GetLatestFinalizedHeader(chainID).GetHeight())
 }
 
 // SetupHeadersForUpdate returns `src` chain's headers to update the client on `dst` chain

--- a/core/headers.go
+++ b/core/headers.go
@@ -53,7 +53,7 @@ var _ SyncHeaders = (*syncHeaders)(nil)
 
 // NewSyncHeaders returns a new instance of SyncHeaders that can be easily
 // kept "reasonably up to date"
-func NewSyncHeaders(src, dst ChainInfoLightClient) (SyncHeaders, error) {
+func NewSyncHeaders(ctx context.Context, src, dst ChainInfoLightClient) (SyncHeaders, error) {
 	logger := GetChainPairLogger(src, dst)
 	if err := ensureDifferentChains(src, dst); err != nil {
 		logger.Error("error ensuring different chains", err)
@@ -62,7 +62,7 @@ func NewSyncHeaders(src, dst ChainInfoLightClient) (SyncHeaders, error) {
 	sh := &syncHeaders{
 		latestFinalizedHeaders: map[string]Header{src.ChainID(): nil, dst.ChainID(): nil},
 	}
-	if err := sh.Updates(context.TODO(), src, dst); err != nil {
+	if err := sh.Updates(ctx, src, dst); err != nil {
 		logger.Error("error updating headers", err)
 		return nil, err
 	}

--- a/core/headers.go
+++ b/core/headers.go
@@ -27,7 +27,7 @@ type SyncHeaders interface {
 	GetQueryContext(chainID string) QueryContext
 
 	// SetupHeadersForUpdate returns `src` chain's headers needed to update the client on `dst` chain
-	SetupHeadersForUpdate(src, dst ChainLightClient) ([]Header, error)
+	SetupHeadersForUpdate(ctx context.Context, src, dst ChainLightClient) ([]Header, error)
 
 	// SetupBothHeadersForUpdate returns both `src` and `dst` chain's headers needed to update the clients on each chain
 	SetupBothHeadersForUpdate(src, dst ChainLightClient) (srcHeaders []Header, dstHeaders []Header, err error)
@@ -122,24 +122,24 @@ func (sh syncHeaders) GetQueryContext(chainID string) QueryContext {
 }
 
 // SetupHeadersForUpdate returns `src` chain's headers to update the client on `dst` chain
-func (sh syncHeaders) SetupHeadersForUpdate(src, dst ChainLightClient) ([]Header, error) {
+func (sh syncHeaders) SetupHeadersForUpdate(ctx context.Context, src, dst ChainLightClient) ([]Header, error) {
 	logger := GetChainPairLogger(src, dst)
 	if err := ensureDifferentChains(src, dst); err != nil {
 		logger.Error("error ensuring different chains", err)
 		return nil, err
 	}
-	return src.SetupHeadersForUpdate(context.TODO(), dst, sh.GetLatestFinalizedHeader(src.ChainID()))
+	return src.SetupHeadersForUpdate(ctx, dst, sh.GetLatestFinalizedHeader(src.ChainID()))
 }
 
 // SetupBothHeadersForUpdate returns both `src` and `dst` chain's headers to update the clients on each chain
 func (sh syncHeaders) SetupBothHeadersForUpdate(src, dst ChainLightClient) ([]Header, []Header, error) {
 	logger := GetChainPairLogger(src, dst)
-	srcHs, err := sh.SetupHeadersForUpdate(src, dst)
+	srcHs, err := sh.SetupHeadersForUpdate(context.TODO(), src, dst)
 	if err != nil {
 		logger.Error("error setting up headers for update on src", err)
 		return nil, nil, err
 	}
-	dstHs, err := sh.SetupHeadersForUpdate(dst, src)
+	dstHs, err := sh.SetupHeadersForUpdate(context.TODO(), dst, src)
 	if err != nil {
 		logger.Error("error setting up headers for update on dst", err)
 		return nil, nil, err

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -299,7 +299,7 @@ func (st *NaiveStrategy) UnrelayedAcknowledgements(src, dst *ProvableChain, sh S
 					"try_limit", rtyAttNum,
 					"error", err.Error(),
 				)
-				sh.Updates(src, dst)
+				sh.Updates(context.TODO(), src, dst)
 			}))
 		})
 	}
@@ -324,7 +324,7 @@ func (st *NaiveStrategy) UnrelayedAcknowledgements(src, dst *ProvableChain, sh S
 					"try_limit", rtyAttNum,
 					"error", err.Error(),
 				)
-				sh.Updates(src, dst)
+				sh.Updates(context.TODO(), src, dst)
 			}))
 		})
 	}

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -495,7 +495,7 @@ func collectAcks(ctx QueryContext, chain *ProvableChain, packets PacketInfoList,
 	return msgs, nil
 }
 
-func (st *NaiveStrategy) UpdateClients(src, dst *ProvableChain, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst bool, sh SyncHeaders, doRefresh bool) (*RelayMsgs, error) {
+func (st *NaiveStrategy) UpdateClients(ctx context.Context, src, dst *ProvableChain, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst bool, sh SyncHeaders, doRefresh bool) (*RelayMsgs, error) {
 	logger := GetChannelPairLogger(src, dst)
 
 	msgs := NewRelayMsgs()
@@ -506,14 +506,14 @@ func (st *NaiveStrategy) UpdateClients(src, dst *ProvableChain, doExecuteRelaySr
 	// check if LC refresh is needed
 	if !needsUpdateForSrc && doRefresh {
 		var err error
-		needsUpdateForSrc, err = dst.CheckRefreshRequired(context.TODO(), src)
+		needsUpdateForSrc, err = dst.CheckRefreshRequired(ctx, src)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if the LC on the src chain needs to be refreshed: %v", err)
 		}
 	}
 	if !needsUpdateForDst && doRefresh {
 		var err error
-		needsUpdateForDst, err = src.CheckRefreshRequired(context.TODO(), dst)
+		needsUpdateForDst, err = src.CheckRefreshRequired(ctx, dst)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check if the LC on the dst chain needs to be refreshed: %v", err)
 		}
@@ -524,7 +524,7 @@ func (st *NaiveStrategy) UpdateClients(src, dst *ProvableChain, doExecuteRelaySr
 		if err != nil {
 			return nil, fmt.Errorf("failed to get relayer address on src chain: %v", err)
 		}
-		hs, err := sh.SetupHeadersForUpdate(context.TODO(), dst, src)
+		hs, err := sh.SetupHeadersForUpdate(ctx, dst, src)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set up headers for updating client on src chain: %v", err)
 		}
@@ -538,7 +538,7 @@ func (st *NaiveStrategy) UpdateClients(src, dst *ProvableChain, doExecuteRelaySr
 		if err != nil {
 			return nil, fmt.Errorf("failed to get relayer address on dst chain: %v", err)
 		}
-		hs, err := sh.SetupHeadersForUpdate(context.TODO(), src, dst)
+		hs, err := sh.SetupHeadersForUpdate(ctx, src, dst)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set up headers for updating client on dst chain: %v", err)
 		}

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -557,12 +557,12 @@ func (st *NaiveStrategy) UpdateClients(src, dst *ProvableChain, doExecuteRelaySr
 	return msgs, nil
 }
 
-func (st *NaiveStrategy) Send(src, dst Chain, msgs *RelayMsgs) {
+func (st *NaiveStrategy) Send(ctx context.Context, src, dst Chain, msgs *RelayMsgs) {
 	logger := GetChannelPairLogger(src, dst)
 
 	msgs.MaxTxSize = st.MaxTxSize
 	msgs.MaxMsgLength = st.MaxMsgLength
-	msgs.Send(context.TODO(), src, dst)
+	msgs.Send(ctx, src, dst)
 
 	logger.Info("msgs relayed",
 		slog.Group("src", "msg_count", len(msgs.Src)),

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -524,7 +524,7 @@ func (st *NaiveStrategy) UpdateClients(src, dst *ProvableChain, doExecuteRelaySr
 		if err != nil {
 			return nil, fmt.Errorf("failed to get relayer address on src chain: %v", err)
 		}
-		hs, err := sh.SetupHeadersForUpdate(dst, src)
+		hs, err := sh.SetupHeadersForUpdate(context.TODO(), dst, src)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set up headers for updating client on src chain: %v", err)
 		}
@@ -538,7 +538,7 @@ func (st *NaiveStrategy) UpdateClients(src, dst *ProvableChain, doExecuteRelaySr
 		if err != nil {
 			return nil, fmt.Errorf("failed to get relayer address on dst chain: %v", err)
 		}
-		hs, err := sh.SetupHeadersForUpdate(src, dst)
+		hs, err := sh.SetupHeadersForUpdate(context.TODO(), src, dst)
 		if err != nil {
 			return nil, fmt.Errorf("failed to set up headers for updating client on dst chain: %v", err)
 		}

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -67,7 +67,7 @@ func (st *NaiveStrategy) SetupRelay(ctx context.Context, src, dst *ProvableChain
 
 func getQueryContext(chain *ProvableChain, sh SyncHeaders, useFinalizedHeader bool) (QueryContext, error) {
 	if useFinalizedHeader {
-		return sh.GetQueryContext(chain.ChainID()), nil
+		return sh.GetQueryContext(context.TODO(), chain.ChainID()), nil
 	} else {
 		height, err := chain.LatestHeight(context.TODO())
 		if err != nil {
@@ -199,14 +199,14 @@ func (st *NaiveStrategy) UnrelayedPackets(src, dst *ProvableChain, sh SyncHeader
 	}, nil
 }
 
-func (st *NaiveStrategy) RelayPackets(src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteRelaySrc, doExecuteRelayDst bool) (*RelayMsgs, error) {
+func (st *NaiveStrategy) RelayPackets(ctx context.Context, src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteRelaySrc, doExecuteRelayDst bool) (*RelayMsgs, error) {
 	logger := GetChannelPairLogger(src, dst)
 	defer logger.TimeTrack(time.Now(), "RelayPackets", "num_src", len(rp.Src), "num_dst", len(rp.Dst))
 
 	msgs := NewRelayMsgs()
 
-	srcCtx := sh.GetQueryContext(src.ChainID())
-	dstCtx := sh.GetQueryContext(dst.ChainID())
+	srcCtx := sh.GetQueryContext(ctx, src.ChainID())
+	dstCtx := sh.GetQueryContext(ctx, dst.ChainID())
 	srcAddress, err := src.GetAddress()
 	if err != nil {
 		logger.Error(
@@ -420,14 +420,14 @@ func logPacketsRelayed(src, dst Chain, num int, obj string, dir string) {
 	)
 }
 
-func (st *NaiveStrategy) RelayAcknowledgements(src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteAckSrc, doExecuteAckDst bool) (*RelayMsgs, error) {
+func (st *NaiveStrategy) RelayAcknowledgements(ctx context.Context, src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteAckSrc, doExecuteAckDst bool) (*RelayMsgs, error) {
 	logger := GetChannelPairLogger(src, dst)
 	defer logger.TimeTrack(time.Now(), "RelayAcknowledgements", "num_src", len(rp.Src), "num_dst", len(rp.Dst))
 
 	msgs := NewRelayMsgs()
 
-	srcCtx := sh.GetQueryContext(src.ChainID())
-	dstCtx := sh.GetQueryContext(dst.ChainID())
+	srcCtx := sh.GetQueryContext(ctx, src.ChainID())
+	dstCtx := sh.GetQueryContext(ctx, dst.ChainID())
 	srcAddress, err := src.GetAddress()
 	if err != nil {
 		logger.Error(

--- a/core/naive-strategy.go
+++ b/core/naive-strategy.go
@@ -562,7 +562,7 @@ func (st *NaiveStrategy) Send(src, dst Chain, msgs *RelayMsgs) {
 
 	msgs.MaxTxSize = st.MaxTxSize
 	msgs.MaxMsgLength = st.MaxMsgLength
-	msgs.Send(src, dst)
+	msgs.Send(context.TODO(), src, dst)
 
 	logger.Info("msgs relayed",
 		slog.Group("src", "msg_count", len(msgs.Src)),

--- a/core/packet-tx.go
+++ b/core/packet-tx.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration) error {
+func SendTransferMsg(ctx context.Context, src, dst *ProvableChain, amount sdk.Coin, dstAddr string, toHeightOffset uint64, toTimeOffset time.Duration) error {
 	logger := GetChannelPairLogger(src, dst)
 	defer logger.TimeTrack(time.Now(), "SendTransferMsg")
 	var (
@@ -16,7 +16,7 @@ func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr string, t
 		timeoutTimestamp uint64
 	)
 
-	h, err := dst.LatestHeight(context.TODO())
+	h, err := dst.LatestHeight(ctx)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr string, t
 		Dst: []sdk.Msg{},
 	}
 
-	if txs.Send(context.TODO(), src, dst); !txs.Success() {
+	if txs.Send(ctx, src, dst); !txs.Success() {
 		err := fmt.Errorf("failed to send transfer message")
 		logger.Error(err.Error(), err)
 		return err

--- a/core/packet-tx.go
+++ b/core/packet-tx.go
@@ -52,7 +52,7 @@ func SendTransferMsg(src, dst *ProvableChain, amount sdk.Coin, dstAddr string, t
 		Dst: []sdk.Msg{},
 	}
 
-	if txs.Send(src, dst); !txs.Success() {
+	if txs.Send(context.TODO(), src, dst); !txs.Success() {
 		err := fmt.Errorf("failed to send transfer message")
 		logger.Error(err.Error(), err)
 		return err

--- a/core/relayMsgs.go
+++ b/core/relayMsgs.go
@@ -47,7 +47,7 @@ func (r *RelayMsgs) IsMaxTx(msgLen, txSize uint64) bool {
 
 // Send sends the messages with appropriate output
 // TODO: Parallelize? Maybe?
-func (r *RelayMsgs) Send(src, dst Chain) {
+func (r *RelayMsgs) Send(ctx context.Context, src, dst Chain) {
 	logger := GetChannelPairLogger(src, dst)
 	//nolint:prealloc // can not be pre allocated
 	var (
@@ -79,7 +79,7 @@ func (r *RelayMsgs) Send(src, dst Chain) {
 			)}
 
 			// Submit the transactions to src chain and update its status
-			msgIDs, err := src.SendMsgs(context.TODO(), msgs)
+			msgIDs, err := src.SendMsgs(ctx, msgs)
 			if err != nil {
 				logger.Error("failed to send msgs", err)
 			} else {
@@ -106,7 +106,7 @@ func (r *RelayMsgs) Send(src, dst Chain) {
 			"side", "src",
 		)}
 
-		msgIDs, err := src.SendMsgs(context.TODO(), msgs)
+		msgIDs, err := src.SendMsgs(ctx, msgs)
 		if err != nil {
 			logger.Error("failed to send msgs", err)
 		} else {
@@ -142,7 +142,7 @@ func (r *RelayMsgs) Send(src, dst Chain) {
 			)}
 
 			// Submit the transaction to dst chain and update its status
-			msgIDs, err := dst.SendMsgs(context.TODO(), msgs)
+			msgIDs, err := dst.SendMsgs(ctx, msgs)
 			if err != nil {
 				logger.Error("failed to send msgs", err)
 			} else {
@@ -169,7 +169,7 @@ func (r *RelayMsgs) Send(src, dst Chain) {
 			"side", "dst",
 		)}
 
-		msgIDs, err := dst.SendMsgs(context.TODO(), msgs)
+		msgIDs, err := dst.SendMsgs(ctx, msgs)
 		if err != nil {
 			logger.Error("failed to send msgs", err)
 		} else {

--- a/core/send.go
+++ b/core/send.go
@@ -9,20 +9,20 @@ import (
 )
 
 // GetFinalizedMsgResult is an utility function that waits for the finalization of the message execution and then returns the result.
-func GetFinalizedMsgResult(chain ProvableChain, msgID MsgID) (MsgResult, error) {
+func GetFinalizedMsgResult(ctx context.Context, chain ProvableChain, msgID MsgID) (MsgResult, error) {
 	var msgRes MsgResult
 
 	avgBlockTime := chain.AverageBlockTime()
 
 	if err := retry.Do(func() error {
 		// query LFH for each retry because it can proceed.
-		lfHeader, err := chain.GetLatestFinalizedHeader(context.TODO())
+		lfHeader, err := chain.GetLatestFinalizedHeader(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to get latest finalized header: %v", err)
 		}
 
 		// query MsgResult for each retry because it can be included in a different block because of reorg
-		msgRes, err = chain.GetMsgResult(context.TODO(), msgID)
+		msgRes, err = chain.GetMsgResult(ctx, msgID)
 		if err != nil {
 			return retry.Unrecoverable(fmt.Errorf("failed to get message result: %v", err))
 		} else if ok, failureReason := msgRes.Status(); !ok {
@@ -43,7 +43,7 @@ func GetFinalizedMsgResult(chain ProvableChain, msgID MsgID) (MsgResult, error) 
 		}
 
 		return nil
-	}, rtyAtt, rtyDel, rtyErr); err != nil {
+	}, rtyAtt, rtyDel, rtyErr, retry.Context(ctx)); err != nil {
 		return nil, err
 	}
 

--- a/core/send.go
+++ b/core/send.go
@@ -38,7 +38,9 @@ func GetFinalizedMsgResult(ctx context.Context, chain ProvableChain, msgID MsgID
 			} else {
 				waitTime = avgBlockTime * time.Duration(msgHeight.GetRevisionHeight()-lfHeight.GetRevisionHeight())
 			}
-			time.Sleep(waitTime)
+			if err := wait(ctx, waitTime); err != nil {
+				return err
+			}
 			return fmt.Errorf("msg(id=%v) not finalied: msg.height(%v) > lfh.height(%v)", msgID, msgHeight, lfHeight)
 		}
 

--- a/core/service.go
+++ b/core/service.go
@@ -110,7 +110,7 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	logger := GetChannelPairLogger(srv.src, srv.dst)
 
 	// First, update the latest headers for src and dst
-	if err := srv.sh.Updates(srv.src, srv.dst); err != nil {
+	if err := srv.sh.Updates(context.TODO(), srv.src, srv.dst); err != nil {
 		logger.Error("failed to update headers", err)
 		return err
 	}

--- a/core/service.go
+++ b/core/service.go
@@ -134,7 +134,7 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	doExecuteRelaySrc, doExecuteRelayDst := srv.shouldExecuteRelay(pseqs)
 	doExecuteAckSrc, doExecuteAckDst := srv.shouldExecuteRelay(aseqs)
 	// update clients
-	if m, err := srv.st.UpdateClients(srv.src, srv.dst, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst, srv.sh, true); err != nil {
+	if m, err := srv.st.UpdateClients(context.TODO(), srv.src, srv.dst, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst, srv.sh, true); err != nil {
 		logger.Error("failed to update clients", err)
 		return err
 	} else {

--- a/core/service.go
+++ b/core/service.go
@@ -158,7 +158,7 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	}
 
 	// send all msgs to src/dst chains
-	srv.st.Send(srv.src, srv.dst, msgs)
+	srv.st.Send(context.TODO(), srv.src, srv.dst, msgs)
 
 	return nil
 }

--- a/core/service.go
+++ b/core/service.go
@@ -96,7 +96,9 @@ func (srv *RelayService) Start(ctx context.Context) error {
 		})); err != nil {
 			return err
 		}
-		time.Sleep(srv.interval)
+		if err := wait(ctx, srv.interval); err != nil {
+			return err
+		}
 	}
 }
 

--- a/core/service.go
+++ b/core/service.go
@@ -18,7 +18,7 @@ func StartService(
 	dstRelayOptimizaInterval time.Duration,
 	dstRelayOptimizeCount uint64,
 ) error {
-	sh, err := NewSyncHeaders(context.TODO(), src, dst)
+	sh, err := NewSyncHeaders(ctx, src, dst)
 	if err != nil {
 		return err
 	}
@@ -83,13 +83,8 @@ func (srv *RelayService) Start(ctx context.Context) error {
 	logger := GetChannelPairLogger(srv.src, srv.dst)
 	for {
 		if err := retry.Do(func() error {
-			select {
-			case <-ctx.Done():
-				return retry.Unrecoverable(ctx.Err())
-			default:
-				return srv.Serve(ctx)
-			}
-		}, rtyAtt, rtyDel, rtyErr, retry.OnRetry(func(n uint, err error) {
+			return srv.Serve(ctx)
+		}, rtyAtt, rtyDel, rtyErr, retry.Context(ctx), retry.OnRetry(func(n uint, err error) {
 			logger.Info(
 				"retrying to serve relays",
 				"src", srv.src.ChainID(),
@@ -110,20 +105,20 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	logger := GetChannelPairLogger(srv.src, srv.dst)
 
 	// First, update the latest headers for src and dst
-	if err := srv.sh.Updates(context.TODO(), srv.src, srv.dst); err != nil {
+	if err := srv.sh.Updates(ctx, srv.src, srv.dst); err != nil {
 		logger.Error("failed to update headers", err)
 		return err
 	}
 
 	// get unrelayed packets
-	pseqs, err := srv.st.UnrelayedPackets(context.TODO(), srv.src, srv.dst, srv.sh, false)
+	pseqs, err := srv.st.UnrelayedPackets(ctx, srv.src, srv.dst, srv.sh, false)
 	if err != nil {
 		logger.Error("failed to get unrelayed packets", err)
 		return err
 	}
 
 	// get unrelayed acks
-	aseqs, err := srv.st.UnrelayedAcknowledgements(context.TODO(), srv.src, srv.dst, srv.sh, false)
+	aseqs, err := srv.st.UnrelayedAcknowledgements(ctx, srv.src, srv.dst, srv.sh, false)
 	if err != nil {
 		logger.Error("failed to get unrelayed acknowledgements", err)
 		return err
@@ -131,10 +126,10 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 
 	msgs := NewRelayMsgs()
 
-	doExecuteRelaySrc, doExecuteRelayDst := srv.shouldExecuteRelay(pseqs)
-	doExecuteAckSrc, doExecuteAckDst := srv.shouldExecuteRelay(aseqs)
+	doExecuteRelaySrc, doExecuteRelayDst := srv.shouldExecuteRelay(ctx, pseqs)
+	doExecuteAckSrc, doExecuteAckDst := srv.shouldExecuteRelay(ctx, aseqs)
 	// update clients
-	if m, err := srv.st.UpdateClients(context.TODO(), srv.src, srv.dst, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst, srv.sh, true); err != nil {
+	if m, err := srv.st.UpdateClients(ctx, srv.src, srv.dst, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst, srv.sh, true); err != nil {
 		logger.Error("failed to update clients", err)
 		return err
 	} else {
@@ -142,7 +137,7 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	}
 
 	// relay packets if unrelayed seqs exist
-	if m, err := srv.st.RelayPackets(context.TODO(), srv.src, srv.dst, pseqs, srv.sh, doExecuteRelaySrc, doExecuteRelayDst); err != nil {
+	if m, err := srv.st.RelayPackets(ctx, srv.src, srv.dst, pseqs, srv.sh, doExecuteRelaySrc, doExecuteRelayDst); err != nil {
 		logger.Error("failed to relay packets", err)
 		return err
 	} else {
@@ -150,7 +145,7 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	}
 
 	// relay acks if unrelayed seqs exist
-	if m, err := srv.st.RelayAcknowledgements(context.TODO(), srv.src, srv.dst, aseqs, srv.sh, doExecuteAckSrc, doExecuteAckDst); err != nil {
+	if m, err := srv.st.RelayAcknowledgements(ctx, srv.src, srv.dst, aseqs, srv.sh, doExecuteAckSrc, doExecuteAckDst); err != nil {
 		logger.Error("failed to relay acknowledgements", err)
 		return err
 	} else {
@@ -158,19 +153,19 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	}
 
 	// send all msgs to src/dst chains
-	srv.st.Send(context.TODO(), srv.src, srv.dst, msgs)
+	srv.st.Send(ctx, srv.src, srv.dst, msgs)
 
 	return nil
 }
 
-func (srv *RelayService) shouldExecuteRelay(seqs *RelayPackets) (bool, bool) {
+func (srv *RelayService) shouldExecuteRelay(ctx context.Context, seqs *RelayPackets) (bool, bool) {
 	logger := GetChannelPairLogger(srv.src, srv.dst)
 
 	srcRelay := false
 	dstRelay := false
 
 	if len(seqs.Src) > 0 {
-		tsDst, err := srv.src.Timestamp(context.TODO(), seqs.Src[0].EventHeight)
+		tsDst, err := srv.src.Timestamp(ctx, seqs.Src[0].EventHeight)
 		if err != nil {
 			return false, false
 		}
@@ -180,7 +175,7 @@ func (srv *RelayService) shouldExecuteRelay(seqs *RelayPackets) (bool, bool) {
 	}
 
 	if len(seqs.Dst) > 0 {
-		tsSrc, err := srv.dst.Timestamp(context.TODO(), seqs.Dst[0].EventHeight)
+		tsSrc, err := srv.dst.Timestamp(ctx, seqs.Dst[0].EventHeight)
 		if err != nil {
 			return false, false
 		}

--- a/core/service.go
+++ b/core/service.go
@@ -18,7 +18,7 @@ func StartService(
 	dstRelayOptimizaInterval time.Duration,
 	dstRelayOptimizeCount uint64,
 ) error {
-	sh, err := NewSyncHeaders(src, dst)
+	sh, err := NewSyncHeaders(context.TODO(), src, dst)
 	if err != nil {
 		return err
 	}

--- a/core/service.go
+++ b/core/service.go
@@ -116,14 +116,14 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	}
 
 	// get unrelayed packets
-	pseqs, err := srv.st.UnrelayedPackets(srv.src, srv.dst, srv.sh, false)
+	pseqs, err := srv.st.UnrelayedPackets(context.TODO(), srv.src, srv.dst, srv.sh, false)
 	if err != nil {
 		logger.Error("failed to get unrelayed packets", err)
 		return err
 	}
 
 	// get unrelayed acks
-	aseqs, err := srv.st.UnrelayedAcknowledgements(srv.src, srv.dst, srv.sh, false)
+	aseqs, err := srv.st.UnrelayedAcknowledgements(context.TODO(), srv.src, srv.dst, srv.sh, false)
 	if err != nil {
 		logger.Error("failed to get unrelayed acknowledgements", err)
 		return err

--- a/core/service.go
+++ b/core/service.go
@@ -142,7 +142,7 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	}
 
 	// relay packets if unrelayed seqs exist
-	if m, err := srv.st.RelayPackets(srv.src, srv.dst, pseqs, srv.sh, doExecuteRelaySrc, doExecuteRelayDst); err != nil {
+	if m, err := srv.st.RelayPackets(context.TODO(), srv.src, srv.dst, pseqs, srv.sh, doExecuteRelaySrc, doExecuteRelayDst); err != nil {
 		logger.Error("failed to relay packets", err)
 		return err
 	} else {
@@ -150,7 +150,7 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 	}
 
 	// relay acks if unrelayed seqs exist
-	if m, err := srv.st.RelayAcknowledgements(srv.src, srv.dst, aseqs, srv.sh, doExecuteAckSrc, doExecuteAckDst); err != nil {
+	if m, err := srv.st.RelayAcknowledgements(context.TODO(), srv.src, srv.dst, aseqs, srv.sh, doExecuteAckSrc, doExecuteAckDst); err != nil {
 		logger.Error("failed to relay acknowledgements", err)
 		return err
 	} else {

--- a/core/strategies.go
+++ b/core/strategies.go
@@ -31,7 +31,7 @@ type StrategyI interface {
 	UpdateClients(src, dst *ProvableChain, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst bool, sh SyncHeaders, doRefresh bool) (*RelayMsgs, error)
 
 	// Send executes submission of msgs to src/dst chains
-	Send(src, dst Chain, msgs *RelayMsgs)
+	Send(ctx context.Context, src, dst Chain, msgs *RelayMsgs)
 }
 
 // StrategyCfg defines which relaying strategy to take for a given path

--- a/core/strategies.go
+++ b/core/strategies.go
@@ -15,14 +15,14 @@ type StrategyI interface {
 
 	// UnrelayedPackets returns packets to execute RecvPacket to on `src` and `dst`.
 	// `includeRelayedButUnfinalized` decides if the result includes packets of which recvPacket has been executed but not finalized
-	UnrelayedPackets(src, dst *ProvableChain, sh SyncHeaders, includeRelayedButUnfinalized bool) (*RelayPackets, error)
+	UnrelayedPackets(ctx context.Context, src, dst *ProvableChain, sh SyncHeaders, includeRelayedButUnfinalized bool) (*RelayPackets, error)
 
 	// RelayPackets executes RecvPacket to the packets contained in `rp` on both chains (`src` and `dst`).
 	RelayPackets(ctx context.Context, src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteRelaySrc, doExecuteRelayDst bool) (*RelayMsgs, error)
 
 	// UnrelayedAcknowledgements returns packets to execute AcknowledgePacket to on `src` and `dst`.
 	// `includeRelayedButUnfinalized` decides if the result includes packets of which acknowledgePacket has been executed but not finalized
-	UnrelayedAcknowledgements(src, dst *ProvableChain, sh SyncHeaders, includeRelayedButUnfinalized bool) (*RelayPackets, error)
+	UnrelayedAcknowledgements(ctx context.Context, src, dst *ProvableChain, sh SyncHeaders, includeRelayedButUnfinalized bool) (*RelayPackets, error)
 
 	// RelayAcknowledgements executes AcknowledgePacket to the packets contained in `rp` on both chains (`src` and `dst`).
 	RelayAcknowledgements(ctx context.Context, src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteAckSrc, doExecuteAckDst bool) (*RelayMsgs, error)

--- a/core/strategies.go
+++ b/core/strategies.go
@@ -28,7 +28,7 @@ type StrategyI interface {
 	RelayAcknowledgements(src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteAckSrc, doExecuteAckDst bool) (*RelayMsgs, error)
 
 	// UpdateClients executes UpdateClient only if needed
-	UpdateClients(src, dst *ProvableChain, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst bool, sh SyncHeaders, doRefresh bool) (*RelayMsgs, error)
+	UpdateClients(ctx context.Context, src, dst *ProvableChain, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst bool, sh SyncHeaders, doRefresh bool) (*RelayMsgs, error)
 
 	// Send executes submission of msgs to src/dst chains
 	Send(ctx context.Context, src, dst Chain, msgs *RelayMsgs)

--- a/core/strategies.go
+++ b/core/strategies.go
@@ -18,14 +18,14 @@ type StrategyI interface {
 	UnrelayedPackets(src, dst *ProvableChain, sh SyncHeaders, includeRelayedButUnfinalized bool) (*RelayPackets, error)
 
 	// RelayPackets executes RecvPacket to the packets contained in `rp` on both chains (`src` and `dst`).
-	RelayPackets(src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteRelaySrc, doExecuteRelayDst bool) (*RelayMsgs, error)
+	RelayPackets(ctx context.Context, src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteRelaySrc, doExecuteRelayDst bool) (*RelayMsgs, error)
 
 	// UnrelayedAcknowledgements returns packets to execute AcknowledgePacket to on `src` and `dst`.
 	// `includeRelayedButUnfinalized` decides if the result includes packets of which acknowledgePacket has been executed but not finalized
 	UnrelayedAcknowledgements(src, dst *ProvableChain, sh SyncHeaders, includeRelayedButUnfinalized bool) (*RelayPackets, error)
 
 	// RelayAcknowledgements executes AcknowledgePacket to the packets contained in `rp` on both chains (`src` and `dst`).
-	RelayAcknowledgements(src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteAckSrc, doExecuteAckDst bool) (*RelayMsgs, error)
+	RelayAcknowledgements(ctx context.Context, src, dst *ProvableChain, rp *RelayPackets, sh SyncHeaders, doExecuteAckSrc, doExecuteAckDst bool) (*RelayMsgs, error)
 
 	// UpdateClients executes UpdateClient only if needed
 	UpdateClients(ctx context.Context, src, dst *ProvableChain, doExecuteRelaySrc, doExecuteRelayDst, doExecuteAckSrc, doExecuteAckDst bool, sh SyncHeaders, doRefresh bool) (*RelayMsgs, error)

--- a/core/utils.go
+++ b/core/utils.go
@@ -1,10 +1,12 @@
 package core
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
@@ -170,4 +172,18 @@ func strToUint64(s string) uint64 {
 		panic(err)
 	}
 	return uint64(v)
+}
+
+func wait(ctx context.Context, d time.Duration) error {
+	// NOTE: We can use time.After with Go 1.23 or later
+	// cf. https://pkg.go.dev/time@go1.23.0#After
+	t := time.NewTimer(d)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
 }

--- a/helpers/query.go
+++ b/helpers/query.go
@@ -10,9 +10,9 @@ import (
 )
 
 // QueryBalance is a helper function for query balance
-func QueryBalance(chain *core.ProvableChain, height ibcexported.Height, address sdk.AccAddress, showDenoms bool) (sdk.Coins, error) {
-	ctx := core.NewQueryContext(context.TODO(), height)
-	coins, err := chain.QueryBalance(ctx, address)
+func QueryBalance(ctx context.Context, chain *core.ProvableChain, height ibcexported.Height, address sdk.AccAddress, showDenoms bool) (sdk.Coins, error) {
+	queryCtx := core.NewQueryContext(ctx, height)
+	coins, err := chain.QueryBalance(queryCtx, address)
 	if err != nil {
 		return nil, err
 	}
@@ -21,7 +21,7 @@ func QueryBalance(chain *core.ProvableChain, height ibcexported.Height, address 
 		return coins, nil
 	}
 
-	dts, err := chain.QueryDenomTraces(ctx, 0, 1000)
+	dts, err := chain.QueryDenomTraces(queryCtx, 0, 1000)
 	if err != nil {
 		return nil, err
 	}

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -71,7 +71,7 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height expo
 	return clientState, consensusState, nil
 }
 
-// SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
+// SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterparty chain
 func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
 	return []core.Header{latestFinalizedHeader.(*mocktypes.Header)}, nil
 }

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -76,8 +76,8 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 	return []core.Header{latestFinalizedHeader.(*mocktypes.Header)}, nil
 }
 
-func (pr *Prover) createMockHeader(height exported.Height) (core.Header, error) {
-	timestamp, err := pr.chain.Timestamp(context.TODO(), height)
+func (pr *Prover) createMockHeader(ctx context.Context, height exported.Height) (core.Header, error) {
+	timestamp, err := pr.chain.Timestamp(ctx, height)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block timestamp at height:%v", height)
 	}
@@ -90,8 +90,8 @@ func (pr *Prover) createMockHeader(height exported.Height) (core.Header, error) 
 	}, nil
 }
 
-func (pr *Prover) getDelayedLatestFinalizedHeight() (exported.Height, error) {
-	height, err := pr.chain.LatestHeight(context.TODO())
+func (pr *Prover) getDelayedLatestFinalizedHeight(ctx context.Context) (exported.Height, error) {
+	height, err := pr.chain.LatestHeight(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get latest height: %v", err)
 	}
@@ -106,11 +106,11 @@ func (pr *Prover) getDelayedLatestFinalizedHeight() (exported.Height, error) {
 }
 
 // GetLatestFinalizedHeader returns the latest finalized header
-func (pr *Prover) GetLatestFinalizedHeader(context.Context) (core.Header, error) {
-	if latestFinalizedHeight, err := pr.getDelayedLatestFinalizedHeight(); err != nil {
+func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, error) {
+	if latestFinalizedHeight, err := pr.getDelayedLatestFinalizedHeight(ctx); err != nil {
 		return nil, err
 	} else {
-		return pr.createMockHeader(latestFinalizedHeight)
+		return pr.createMockHeader(ctx, latestFinalizedHeight)
 	}
 }
 

--- a/provers/mock/prover.go
+++ b/provers/mock/prover.go
@@ -44,7 +44,7 @@ func (pr *Prover) SetupForRelay(ctx context.Context) error {
 
 // CreateInitialLightClientState creates a pair of ClientState and ConsensusState for building MsgCreateClient submitted to the counterparty chain
 func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height exported.Height) (exported.ClientState, exported.ConsensusState, error) {
-	if head, err := pr.GetLatestFinalizedHeader(context.TODO()); err != nil {
+	if head, err := pr.GetLatestFinalizedHeader(ctx); err != nil {
 		return nil, nil, fmt.Errorf("failed to get the latest finalized header: %v", err)
 	} else if height == nil {
 		height = head.GetHeight()
@@ -60,7 +60,7 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height expo
 	}
 
 	var consensusState exported.ConsensusState
-	if timestamp, err := pr.chain.Timestamp(context.TODO(), height); err != nil {
+	if timestamp, err := pr.chain.Timestamp(ctx, height); err != nil {
 		return nil, nil, fmt.Errorf("get timestamp at height@%v: %v", height, err)
 	} else {
 		consensusState = &mocktypes.ConsensusState{


### PR DESCRIPTION
# Description

This PR is the third phase and part of the fourth phase of the integration with OpenTelemetry described on https://github.com/hyperledger-labs/yui-relayer/pull/153.

In the first part of the commits, I have added a context argument to the methods called from various code and added `context.TODO()` to each caller. I have also made the downstream methods (the methods called from the method) use the context argument appropriately and added a context argument if necessary.

In the second part of the commits, I have replaced `context.TODO()` with `cmd.Context()` in the cmd package and made the downstream methods use the context argument appropriately.

In the following PRs (the fourth phase), I will do the same thing in other repositories.

# Behavior changes

This PR also makes the relayer shutdown gracefully (https://github.com/hyperledger-labs/yui-relayer/pull/154/commits/526ab84f9ab5b5ef87cfe57a1f1270d292a57e02) when it receives SIGINT and SIGTERM.
Here is the output from the relayer started by `service start` when I pressed `^C`:

Before

```
^C
```

After

```
^C{"time":"2025-02-27T18:13:43.798834915+09:00","level":"INFO","source":{"function":"github.com/hyperledger-labs/yui-relayer/cmd.notifyContext.func1","file":"/home/arabiki/.local/share/mise/installs/go/1.23.2/packages/pkg/mod/github.com/abicky/yui-relayer@v0.0.0-20250227090206-0b719e8876a6/cmd/root.go","line":141},"msg":"Received SIGINT. Shutting down..."}
2025/02/27 18:13:44 context canceled
```

# What I have checked

I have confirmed that there is no longer `context.TODO()` as follows:

```
% git grep 'context\.TODO' | wc
      0       0       0
```

I have also ensured that the CI passes in the following repositories:

* https://github.com/datachainlab/yui-relayer-build/tree/refs/heads/intergate-with-opentelemetry
    - https://github.com/datachainlab/yui-relayer-build/actions/runs/13578275247
    - https://github.com/datachainlab/yui-relayer-build/actions/runs/13578275252
    - https://github.com/datachainlab/yui-relayer-build/actions/runs/13578275249
* https://github.com/datachainlab/cosmos-ethereum-ibc-lcp/pull/71
    - https://github.com/datachainlab/cosmos-ethereum-ibc-lcp/actions/runs/13578334544