### PR TITLE
Fix bug where some iterations don't wait before next loop

### DIFF
--- a/core/export_test.go
+++ b/core/export_test.go
@@ -1,3 +1,0 @@
-package core
-
-var RunUntilComplete = runUntilComplete

--- a/core/export_test.go
+++ b/core/export_test.go
@@ -1,0 +1,3 @@
+package core
+
+var RunUntilComplete = runUntilComplete

--- a/core/utils.go
+++ b/core/utils.go
@@ -187,3 +187,27 @@ func wait(ctx context.Context, d time.Duration) error {
 		return nil
 	}
 }
+
+func runUntilComplete(ctx context.Context, interval time.Duration, fn func() (bool, error)) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	if complete, err := fn(); err != nil {
+		return err
+	} else if complete {
+		return nil
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if complete, err := fn(); err != nil {
+				return err
+			} else if complete {
+				return nil
+			}
+		}
+	}
+}

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -1,0 +1,133 @@
+package core_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-labs/yui-relayer/core"
+)
+
+func TestRunUntilComplete(t *testing.T) {
+	runtimeError := errors.New("runtime error")
+
+	tests := []struct {
+		name    string
+		fn      func() (bool, error)
+		attempt int
+		cancel  bool
+		err     error
+	}{
+		{
+			name: "Complete immediately",
+			fn: func() (bool, error) {
+				return true, nil
+			},
+			attempt: 1,
+			cancel:  false,
+			err:     nil,
+		},
+		{
+			name: "Complete on the second try",
+			fn: func() func() (bool, error) {
+				attempt := 0
+				return func() (bool, error) {
+					attempt++
+					if attempt == 2 {
+						return true, nil
+					} else {
+						return false, nil
+					}
+				}
+			}(),
+			attempt: 2,
+			cancel:  false,
+			err:     nil,
+		},
+		{
+			name: "Complete on the third try",
+			fn: func() func() (bool, error) {
+				attempt := 0
+				return func() (bool, error) {
+					attempt++
+					if attempt == 3 {
+						return true, nil
+					} else {
+						return false, nil
+					}
+				}
+			}(),
+			attempt: 3,
+			cancel:  false,
+			err:     nil,
+		},
+		{
+			name: "Error immediately",
+			fn: func() (bool, error) {
+				return false, runtimeError
+			},
+			attempt: 1,
+			cancel:  false,
+			err:     runtimeError,
+		},
+		{
+			name: "Error on the second try",
+			fn: func() func() (bool, error) {
+				attempt := 0
+				return func() (bool, error) {
+					attempt++
+					if attempt == 2 {
+						return false, runtimeError
+					} else {
+						return false, nil
+					}
+				}
+			}(),
+			attempt: 2,
+			cancel:  false,
+			err:     runtimeError,
+		},
+		{
+			name: "Error immediately with complete true",
+			fn: func() (bool, error) {
+				return true, runtimeError
+			},
+			attempt: 1,
+			cancel:  false,
+			err:     runtimeError,
+		},
+		{
+			name: "Cancelled",
+			fn: func() (bool, error) {
+				return false, nil
+			},
+			attempt: 1,
+			cancel:  true,
+			err:     context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			if tt.cancel {
+				cancel()
+			} else {
+				defer cancel()
+			}
+
+			attempt := 0
+			fn := func() (bool, error) {
+				attempt++
+				return tt.fn()
+			}
+			if err := core.RunUntilComplete(ctx, time.Millisecond, fn); err != tt.err {
+				t.Errorf("err = %v; want %v", err, tt.err)
+			}
+			if attempt != tt.attempt {
+				t.Errorf("attempt = %v; want %v", attempt, tt.attempt)
+			}
+		})
+	}
+}

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -12,14 +12,14 @@ func TestRunUntilComplete(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		fn      func() (bool, error)
+		fn      func(int) (bool, error)
 		attempt int
 		cancel  bool
 		err     error
 	}{
 		{
 			name: "Complete immediately",
-			fn: func() (bool, error) {
+			fn: func(_ int) (bool, error) {
 				return true, nil
 			},
 			attempt: 1,
@@ -28,41 +28,33 @@ func TestRunUntilComplete(t *testing.T) {
 		},
 		{
 			name: "Complete on the second try",
-			fn: func() func() (bool, error) {
-				attempt := 0
-				return func() (bool, error) {
-					attempt++
-					if attempt == 2 {
-						return true, nil
-					} else {
-						return false, nil
-					}
+			fn: func(attempt int) (bool, error) {
+				if attempt == 2 {
+					return true, nil
+				} else {
+					return false, nil
 				}
-			}(),
+			},
 			attempt: 2,
 			cancel:  false,
 			err:     nil,
 		},
 		{
 			name: "Complete on the third try",
-			fn: func() func() (bool, error) {
-				attempt := 0
-				return func() (bool, error) {
-					attempt++
-					if attempt == 3 {
-						return true, nil
-					} else {
-						return false, nil
-					}
+			fn: func(attempt int) (bool, error) {
+				if attempt == 3 {
+					return true, nil
+				} else {
+					return false, nil
 				}
-			}(),
+			},
 			attempt: 3,
 			cancel:  false,
 			err:     nil,
 		},
 		{
 			name: "Error immediately",
-			fn: func() (bool, error) {
+			fn: func(_ int) (bool, error) {
 				return false, runtimeError
 			},
 			attempt: 1,
@@ -71,24 +63,20 @@ func TestRunUntilComplete(t *testing.T) {
 		},
 		{
 			name: "Error on the second try",
-			fn: func() func() (bool, error) {
-				attempt := 0
-				return func() (bool, error) {
-					attempt++
-					if attempt == 2 {
-						return false, runtimeError
-					} else {
-						return false, nil
-					}
+			fn: func(attempt int) (bool, error) {
+				if attempt == 2 {
+					return false, runtimeError
+				} else {
+					return false, nil
 				}
-			}(),
+			},
 			attempt: 2,
 			cancel:  false,
 			err:     runtimeError,
 		},
 		{
 			name: "Error immediately with complete true",
-			fn: func() (bool, error) {
+			fn: func(_ int) (bool, error) {
 				return true, runtimeError
 			},
 			attempt: 1,
@@ -97,7 +85,7 @@ func TestRunUntilComplete(t *testing.T) {
 		},
 		{
 			name: "Cancelled",
-			fn: func() (bool, error) {
+			fn: func(_ int) (bool, error) {
 				return false, nil
 			},
 			attempt: 1,
@@ -118,7 +106,7 @@ func TestRunUntilComplete(t *testing.T) {
 			attempt := 0
 			fn := func() (bool, error) {
 				attempt++
-				return tt.fn()
+				return tt.fn(attempt)
 			}
 			if err := runUntilComplete(ctx, time.Millisecond, fn); err != tt.err {
 				t.Errorf("err = %v; want %v", err, tt.err)

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -1,12 +1,10 @@
-package core_test
+package core
 
 import (
 	"context"
 	"errors"
 	"testing"
 	"time"
-
-	"github.com/hyperledger-labs/yui-relayer/core"
 )
 
 func TestRunUntilComplete(t *testing.T) {
@@ -122,7 +120,7 @@ func TestRunUntilComplete(t *testing.T) {
 				attempt++
 				return tt.fn()
 			}
-			if err := core.RunUntilComplete(ctx, time.Millisecond, fn); err != tt.err {
+			if err := runUntilComplete(ctx, time.Millisecond, fn); err != tt.err {
 				t.Errorf("err = %v; want %v", err, tt.err)
 			}
 			if attempt != tt.attempt {


### PR DESCRIPTION
This PR fixes the bug where some iterations skip calling `<-ticker.C` before proceeding to the next loop.
This is a regression introduced in https://github.com/hyperledger-labs/yui-relayer/pull/154.

I have also confirmed the behavior manually using https://github.com/datachainlab/yui-relayer-build with the following changes:

```diff
diff --git a/tests/cases/tm2eth/Makefile b/tests/cases/tm2eth/Makefile
index 0fa0935..9659f57 100644
--- a/tests/cases/tm2eth/Makefile
+++ b/tests/cases/tm2eth/Makefile
@@ -13,8 +13,8 @@ test:
 	./scripts/init-rly
 	./scripts/handshake
 	./scripts/test-channel-upgrade
-	./scripts/test-mockapp-packet-relay
-	./scripts/test-ics20-packet-relay
+	# ./scripts/test-mockapp-packet-relay
+	# ./scripts/test-ics20-packet-relay
 
 .PHONY: network-down
 network-down:
diff --git a/tests/cases/tm2eth/configs/demo/ibc-0.json b/tests/cases/tm2eth/configs/demo/ibc-0.json
index c683dd6..53719bb 100644
--- a/tests/cases/tm2eth/configs/demo/ibc-0.json
+++ b/tests/cases/tm2eth/configs/demo/ibc-0.json
@@ -12,6 +12,6 @@
   },
   "prover": {
     "@type": "/relayer.provers.mock.config.ProverConfig",
-    "finality_delay": 0
+    "finality_delay": 10
   }
 }
diff --git a/tests/cases/tm2eth/scripts/handshake b/tests/cases/tm2eth/scripts/handshake
index 5ff7521..f1848f5 100755
--- a/tests/cases/tm2eth/scripts/handshake
+++ b/tests/cases/tm2eth/scripts/handshake
@@ -20,8 +20,8 @@ $RLY paths add $CHAINID_ONE $CHAINID_TWO $MOCKAPP_PATH --file=./configs/mockapp-
 $RLY paths add $CHAINID_ONE $CHAINID_TWO $ICS20_PATH   --file=./configs/ics20-path.json
 
 retry 5 $RLY tx clients    $MOCKAPP_PATH
-retry 5 $RLY tx connection $MOCKAPP_PATH
-retry 5 $RLY tx channel    $MOCKAPP_PATH
+retry 5 $RLY tx connection $MOCKAPP_PATH --timeout 3s
+retry 5 $RLY tx channel    $MOCKAPP_PATH --timeout 3s
 
 # copy client-id's from mockapp-path to ics20-path
 $RLY paths edit $ICS20_PATH src client-id $($RLY paths list --json | jq --raw-output --arg path_name $MOCKAPP_PATH '.[$path_name].src."client-id"')
```