### PR TITLE
Display error message from coreutil.Unwrap* as well

### DIFF
--- a/chains/tendermint/cmd/keys.go
+++ b/chains/tendermint/cmd/keys.go
@@ -44,7 +44,7 @@ func keysAddCmd(ctx *config.Context) *cobra.Command {
 
 			chain, err := coreutil.UnwrapChain[*tendermint.Chain](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Chain", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Chain: %v", args[0], err)
 			}
 
 			var keyName string
@@ -108,7 +108,7 @@ func keysRestoreCmd(ctx *config.Context) *cobra.Command {
 
 			chain, err := coreutil.UnwrapChain[*tendermint.Chain](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Chain", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Chain: %v", args[0], err)
 			}
 
 			if chain.KeyExists(keyName) {
@@ -148,7 +148,7 @@ func keysShowCmd(ctx *config.Context) *cobra.Command {
 
 			chain, err := coreutil.UnwrapChain[*tendermint.Chain](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Chain", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Chain: %v", args[0], err)
 			}
 
 			var keyName string
@@ -193,7 +193,7 @@ func keysListCmd(ctx *config.Context) *cobra.Command {
 
 			chain, err := coreutil.UnwrapChain[*tendermint.Chain](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Chain", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Chain: %v", args[0], err)
 			}
 
 			info, err := chain.Keybase.List()

--- a/chains/tendermint/cmd/keys.go
+++ b/chains/tendermint/cmd/keys.go
@@ -29,7 +29,7 @@ func keysCmd(ctx *config.Context) *cobra.Command {
 	return cmd
 }
 
-// keysAddCmd respresents the `keys add` command
+// keysAddCmd represents the `keys add` command
 func keysAddCmd(ctx *config.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add [chain-id] [[name]]",

--- a/chains/tendermint/cmd/light.go
+++ b/chains/tendermint/cmd/light.go
@@ -44,11 +44,11 @@ func initLightCmd(ctx *config.Context) *cobra.Command {
 
 			chain, err := coreutil.UnwrapChain[*tendermint.Chain](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Chain", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Chain: %v", args[0], err)
 			}
 			prover, err := coreutil.UnwrapProver[*tendermint.Prover](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Prover", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Prover: %v", args[0], err)
 			}
 
 			db, df, err := prover.NewLightDB(cmd.Context())
@@ -107,7 +107,7 @@ func updateLightCmd(ctx *config.Context) *cobra.Command {
 
 			prover, err := coreutil.UnwrapProver[*tendermint.Prover](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Prover", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Prover: %v", args[0], err)
 			}
 
 			bh, err := prover.GetLatestLightHeader(cmd.Context())
@@ -144,11 +144,11 @@ func lightHeaderCmd(ctx *config.Context) *cobra.Command {
 
 			chain, err := coreutil.UnwrapChain[*tendermint.Chain](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Chain", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Chain: %v", args[0], err)
 			}
 			prover, err := coreutil.UnwrapProver[*tendermint.Prover](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Prover", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Prover: %v", args[0], err)
 			}
 
 			var header *tmclient.Header
@@ -210,7 +210,7 @@ func deleteLightCmd(ctx *config.Context) *cobra.Command {
 
 			prover, err := coreutil.UnwrapProver[*tendermint.Prover](c)
 			if err != nil {
-				return fmt.Errorf("Chain %q is not a tendermint.Prover", args[0])
+				return fmt.Errorf("Chain %q is not a tendermint.Prover: %v", args[0], err)
 			}
 
 			err = prover.DeleteLightDB()

--- a/tests/cases/tm2tm/scripts/init-rly
+++ b/tests/cases/tm2tm/scripts/init-rly
@@ -22,7 +22,7 @@ fi
 rm -rf ${RELAYER_CONF} &> /dev/null
 
 ${RLY} config init
-${RLY} chains add-dir configs/demo/
+${RLY} chains add-dir ${SCRIPT_DIR}/../configs/demo/
 
 # setup key for tendermint client
 SEED0=$(jq -r '.mnemonic' < ${FIXTURES_DIR}/tendermint/ibc0/key_seed.json)

--- a/tests/cases/tmmock2tmmock/scripts/init-rly
+++ b/tests/cases/tmmock2tmmock/scripts/init-rly
@@ -22,7 +22,7 @@ fi
 rm -rf ${RELAYER_CONF} &> /dev/null
 
 ${RLY} config init
-${RLY} chains add-dir configs/demo/
+${RLY} chains add-dir ${SCRIPT_DIR}/../configs/demo/
 
 # setup key for tendermint client
 SEED0=$(jq -r '.mnemonic' < ${FIXTURES_DIR}/tendermint/ibc0/key_seed.json)


### PR DESCRIPTION
This PR modifies the error message to include the error from `coreutil.Unwrap*` functions when a user runs some commands with an unexpected chain argument.
This improvement was suggested by Masa-san pointed out in the comment https://github.com/datachainlab/lcp-go/pull/51#discussion_r2121310536.

Additionally, this PR includes some trivial changes.

## Before
```console
$ yrly tendermint keys list ibc1
2025/06/03 16:10:31 Chain "ibc1" is not a tendermint.Chain
$ yrly tendermint light init ibc1
-- snip --
2025/06/03 16:10:51 Chain "ibc1" is not a tendermint.Chain
-- snip --
$ yrly tendermint light init ibc0
2025/06/03 16:11:04 Chain "ibc0" is not a tendermint.Prover
```

## After

```console
$ yrly tendermint keys list ibc1
2025/06/03 16:09:37 Chain "ibc1" is not a tendermint.Chain: failed to unwrap chain: expected=*tendermint.Chain, actual=*ethereum.Chain
$ yrly tendermint light init ibc1
-- snip --
2025/06/03 16:07:52 Chain "ibc1" is not a tendermint.Chain: failed to unwrap chain: expected=*tendermint.Chain, actual=*ethereum.Chain
-- snip --
$ yrly tendermint light init ibc0
2025/06/03 16:09:13 Chain "ibc0" is not a tendermint.Prover: failed to unwrap prover: expected=*tendermint.Prover, actual=*mock.Prover
```