### PR TITLE
Add version information support

### DIFF
--- a/cmd/module.go
+++ b/cmd/module.go
@@ -2,7 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"reflect"
+	"runtime/debug"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/hyperledger-labs/yui-relayer/config"
 	"github.com/spf13/cobra"
@@ -27,16 +31,37 @@ func showModulesCmd(ctx *config.Context) *cobra.Command {
 		Use:   "show",
 		Short: "Shows a list of modules included in the relayer",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			names := make([]string, len(ctx.Modules))
+			modules := make([]string, len(ctx.Modules))
+			bi, _ := debug.ReadBuildInfo()
 			for i, m := range ctx.Modules {
-				names[i] = m.Name()
+				modules[i] = m.Name() + " " + retrieveModuleInfo(bi, m)
 			}
-			sort.Strings(names)
-			for _, name := range names {
-				fmt.Printf("%v\n", name)
+			sort.Strings(modules)
+			for _, module := range modules {
+				fmt.Printf("%v\n", module)
 			}
 			return nil
 		},
 	}
 	return cmd
+}
+
+func retrieveModuleInfo(info *debug.BuildInfo, m config.ModuleI) string {
+	if info == nil {
+		return ""
+	}
+
+	pkgPath := reflect.TypeOf(m).PkgPath()
+	if strings.HasPrefix(pkgPath, info.Main.Path) {
+		return info.Main.Path + " " + info.Main.Version
+	}
+
+	i := slices.IndexFunc(info.Deps, func(dm *debug.Module) bool {
+		return strings.HasPrefix(pkgPath, dm.Path)
+	})
+	if i == -1 {
+		return ""
+	}
+
+	return info.Deps[i].Path + " " + info.Deps[i].Version
 }

--- a/tests/cases/tm2tm/scripts/init-rly
+++ b/tests/cases/tm2tm/scripts/init-rly
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -eux
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
@@ -20,6 +20,9 @@ if ! [ -x ${RLY_BINARY} ]; then
 fi
 
 rm -rf ${RELAYER_CONF} &> /dev/null
+
+${RLY} --version
+${RLY} modules show
 
 ${RLY} config init
 ${RLY} chains add-dir ${SCRIPT_DIR}/../configs/demo/

--- a/tests/cases/tmmock2tmmock/scripts/init-rly
+++ b/tests/cases/tmmock2tmmock/scripts/init-rly
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+set -eux
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
@@ -20,6 +20,9 @@ if ! [ -x ${RLY_BINARY} ]; then
 fi
 
 rm -rf ${RELAYER_CONF} &> /dev/null
+
+${RLY} --version
+${RLY} modules show
 
 ${RLY} config init
 ${RLY} chains add-dir ${SCRIPT_DIR}/../configs/demo/


### PR DESCRIPTION
This PR introduces `--version` flag to the root command and enhances the modules show command to include detailed information, allowing users to check the version of the tool and modules without `go`.

Here are the outputs:

```console
$ ./build/yrly --version
yrly version 0.5.17-0.20250705133023-7a2a6bd96893
$ ./build/yrly modules show
mock-client github.com/hyperledger-labs/yui-relayer v0.5.17-0.20250705133023-7a2a6bd96893
tendermint github.com/hyperledger-labs/yui-relayer v0.5.17-0.20250705133023-7a2a6bd96893
```

I have also verified the output using the github.com/datachainlab/cosmos-ethereum-ibc-lcp repository with the following changes:

```diff
diff --git a/go.mod b/go.mod
index 02016aa..30abdf5 100644
--- a/go.mod
+++ b/go.mod
@@ -266,3 +266,5 @@ require (
        rsc.io/tmplfunc v0.0.3 // indirect
        sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/hyperledger-labs/yui-relayer => ../../hyperledger-labs/yui-relayer
diff --git a/go.sum b/go.sum
index 22a3a94..610fcce 100644
--- a/go.sum
+++ b/go.sum
@@ -799,8 +799,6 @@ github.com/huandu/skiplist v1.2.0/go.mod h1:7v3iFjLcSAzO4fN5B8dvebvo/qsfumiLiDXM
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/huin/goupnp v1.3.0 h1:UvLUlWDNpoUdYzb2TCn+MuTWtcjXKSza2n6CBdQ0xXc=
 github.com/huin/goupnp v1.3.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
-github.com/hyperledger-labs/yui-relayer v0.5.16 h1:NauHZ08JsfIvkzopafR/5/TbRCAH7JSUgqm7YrUEQ/4=
-github.com/hyperledger-labs/yui-relayer v0.5.16/go.mod h1:tGNMIE1y4cGNyRRKhR9rfBtCGLVjgejf3EIXouvdDQc=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
```

Here are the outputs:

```console
$ ./bin/yrly --version
yrly version 0.5.16
$ ./bin/yrly modules show
ethereum-light-client github.com/datachainlab/ethereum-ibc-relay-prover v0.3.14
ethereum.chain github.com/datachainlab/ethereum-ibc-relay-chain v0.3.18
lcp-prover github.com/datachainlab/lcp-go v0.2.21
lcp-tendermint github.com/datachainlab/lcp-go v0.2.21
lcp.signers.raw github.com/datachainlab/lcp-go v0.2.21
relayer.signers.hd github.com/datachainlab/ibc-hd-signer v0.1.2
tendermint github.com/hyperledger-labs/yui-relayer v0.5.16
```