### PR TITLE
Flip the order of calling SetupHeadersForUpdate and ProveState

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+yui-relayer is an IBC relayer implementation (binary name: `yrly`) that supports heterogeneous blockchains — Cosmos/Tendermint (ibc-go), EVM chains (ibc-solidity), Hyperledger Fabric, Corda, etc. The Tendermint support is a fork of cosmos/relayer. Versioning: "v0.Y.Z" where Y tracks the ibc-go major version (current branch v0.5 ↔ ibc-go v8).
+
+## Commands
+
+```sh
+make build        # builds ./build/yrly
+make test         # runs `go generate ./...` (mockgen) then `go test -v ./...`
+make pre-commit   # go mod tidy + go fmt ./... (CI fails if this leaves a diff)
+make proto-gen    # regenerate Go code from proto/ (requires Docker; uses cosmos proto-builder image)
+```
+
+Run a single test:
+
+```sh
+go generate ./...                       # needed once: core tests depend on generated core/mock_chain_test.go
+go test -v ./core/ -run TestName
+```
+
+### E2E tests (tests/)
+
+CI runs E2E cases under `tests/cases/` (e.g. `tm2tm`, `tmmock2tmmock`) against Docker-based Tendermint chains. Requires Docker, `expect`, `jq`, and the relayer binary at `./build/yrly`.
+
+```sh
+cd tests/chains/tendermint && make docker-images   # build chain images (once)
+cd tests/cases/tm2tm
+make network       # docker compose up chains
+make test          # runs scripts: fixture, init-rly, handshake, test-tx, test-service, ...
+make network-down
+```
+
+## Architecture
+
+### Module system (pluggable chains/provers)
+
+The relayer supports new chains without forking: it is used as a library, and chain/prover support is provided via modules implementing `config.ModuleI` (`config/module.go`): `Name()`, `RegisterInterfaces(registry)` (registers `ChainConfig`/`ProverConfig` protobuf implementations), and `GetCmd(ctx)` (chain-specific cobra subcommands). `main.go` passes modules to `cmd.Execute(...)`; built-in modules are `chains/tendermint`, `chains/debug`, `provers/mock`, `provers/debug`.
+
+Chains and provers are instantiated at runtime from the JSON config file: the `"@type"` field (protobuf Any type URL, e.g. `/relayer.chains.tendermint.config.ChainConfig`) selects a registered config type, and its `Build()` method constructs the `Chain`/`Prover`. Proto definitions for configs live in `proto/relayer/...`; generated code goes next to the consuming Go packages.
+
+### Core abstractions (core/)
+
+- **`Chain`** (`core/chain.go`): sends transactions (`SendMsgs`/`GetMsgResult`) and queries chain state (IBC state, packets, balances). Deliberately unaware of finality.
+- **`Prover`** (`core/provers.go`): `LightClient` (create/update client states, `GetLatestFinalizedHeader`, `SetupHeadersForUpdate` returning a header stream channel) + `StateProver` (`ProveState`). Finality decisions live here, not in `Chain`.
+- **`ProvableChain`** (`core/provable-chain.go`): struct embedding one `Chain` + one `Prover`; this is what the rest of core operates on.
+- **`PathEnd`/`Path`** (`core/pathEnd.go`, `core/path.go`): the client/connection/channel identifiers on each side of a relay path.
+- **`StrategyI`** (`core/strategies.go`): computes unrelayed packets/acks/timeouts and builds relay messages. Only implementation: `naive` (`core/naive-strategy.go`).
+- **`RelayService`** (`core/service.go`): the `service start` polling loop — syncs headers (`SyncHeaders` in `core/headers.go`), asks the strategy for unrelayed packets/acks, optionally batches ("relay optimization" via interval/count thresholds), and sends msgs.
+- Handshake logic (`client.go`, `connection.go`, `channel.go`, `channel-upgrade.go`) implements `tx clients/connection/channel/channel-upgrade` as retriable state machines that inspect both ends and send the next handshake msg.
+
+### CLI (cmd/)
+
+Cobra commands: `config`, `chains`, `paths`, `tx` (handshake + relay), `query`, `service`, `transfer`, `modules`. Global flags bind to viper with env prefix `YRLY_` (e.g. `--enable-telemetry` ↔ `YRLY_ENABLE_TELEMETRY`). Default home is `$HOME/.yui-relayer` with config at `config/config.json`.
+
+### Supporting packages
+
+- **`otelcore/`**: OpenTelemetry tracing bridges (`otelcore.NewChain`/`NewProver`) that wrap Chain/Prover; modules opt in by returning them from `Build()`. `coreutil.UnwrapChain`/`UnwrapProver` recover the concrete implementation from a wrapped `ProvableChain`.
+- **`signer/`**: generic `Signer`/`SignerConfig` interfaces so chain modules can plug in alternative signing backends.
+- **`log/`**: slog-based `RelayLogger` used throughout core.
+- **`internal/telemetry`**: OTel setup (traces/metrics/logs exporters configured via `OTEL_*` env vars).

--- a/cmd/tx.go
+++ b/cmd/tx.go
@@ -415,19 +415,19 @@ func channelUpgradeCancelCmd(ctx *config.Context) *cobra.Command {
 }
 
 func relayMsgs(ctx context.Context, st core.StrategyI, src, dst *core.ProvableChain, isSrcToDst bool, packets core.PacketInfoList, sh core.SyncHeaders, doExecuteRelay, doExecuteAck, doExecuteTimeout, doRefresh bool) ([]sdk.Msg, error) {
-	var msgs []sdk.Msg
+	packetMsgs, err := st.RelayPackets(ctx, src, dst, isSrcToDst, packets, sh, doExecuteRelay)
+	if err != nil {
+		return nil, err
+	}
 
+	// updateClients must be called after all proofs are generated, but the resulting msgs must precede them in the tx
+	var msgs []sdk.Msg
 	if m, err := st.UpdateClients(ctx, src, dst, isSrcToDst, doExecuteRelay, doExecuteAck, doExecuteTimeout, sh, doRefresh); err != nil {
 		return nil, err
 	} else {
 		msgs = append(msgs, m...)
 	}
-
-	if m, err := st.RelayPackets(ctx, src, dst, isSrcToDst, packets, sh, doExecuteRelay); err != nil {
-		return nil, err
-	} else {
-		msgs = append(msgs, m...)
-	}
+	msgs = append(msgs, packetMsgs...)
 	return msgs, nil
 }
 
@@ -496,35 +496,37 @@ func relayMsgsCmd(ctx *config.Context) *cobra.Command {
 				doRefresh := viper.GetBool(flagDoRefresh)
 
 				eg.Go(func() error {
+					// Collect timeout messages for dst's packets (DstTimeout → dst chain)
+					var timeoutMsgs []sdk.Msg
+					if doExecuteTimeoutDst {
+						var err error
+						timeoutMsgs, err = st.RelayTimeoutPackets(cmd.Context(), c[dst], c[src], sp.DstTimeout, sh, true)
+						if err != nil {
+							return err
+						}
+					}
 					m, err := relayMsgs(cmd.Context(), st, c[src], c[dst], true, sp.Src, sh, doExecuteRelayDst, doExecuteAckDst, doExecuteTimeoutDst, doRefresh)
 					if err != nil {
 						return err
 					}
-					// Add timeout messages for dst's packets (DstTimeout → dst chain)
-					if doExecuteTimeoutDst {
-						timeoutMsgs, err := st.RelayTimeoutPackets(cmd.Context(), c[dst], c[src], sp.DstTimeout, sh, true)
-						if err != nil {
-							return err
-						}
-						m = append(m, timeoutMsgs...)
-					}
-					msgs.Dst = m
+					msgs.Dst = append(m, timeoutMsgs...)
 					return nil
 				})
 				eg.Go(func() error {
+					// Collect timeout messages for src's packets (SrcTimeout → src chain)
+					var timeoutMsgs []sdk.Msg
+					if doExecuteTimeoutSrc {
+						var err error
+						timeoutMsgs, err = st.RelayTimeoutPackets(cmd.Context(), c[src], c[dst], sp.SrcTimeout, sh, true)
+						if err != nil {
+							return err
+						}
+					}
 					m, err := relayMsgs(cmd.Context(), st, c[src], c[dst], false, sp.Dst, sh, doExecuteRelaySrc, doExecuteAckSrc, doExecuteTimeoutSrc, doRefresh)
 					if err != nil {
 						return err
 					}
-					// Add timeout messages for src's packets (SrcTimeout → src chain)
-					if doExecuteTimeoutSrc {
-						timeoutMsgs, err := st.RelayTimeoutPackets(cmd.Context(), c[src], c[dst], sp.SrcTimeout, sh, true)
-						if err != nil {
-							return err
-						}
-						m = append(m, timeoutMsgs...)
-					}
-					msgs.Src = m
+					msgs.Src = append(m, timeoutMsgs...)
 					return nil
 				})
 
@@ -546,20 +548,20 @@ func relayMsgsCmd(ctx *config.Context) *cobra.Command {
 }
 
 func relayAcks(ctx context.Context, st core.StrategyI, src, dst *core.ProvableChain, isSrcToDst bool, acks core.PacketInfoList, sh core.SyncHeaders, doExecuteRelay, doExecuteAck, doRefresh bool) ([]sdk.Msg, error) {
-	var msgs []sdk.Msg
+	ackMsgs, err := st.RelayAcknowledgements(ctx, src, dst, isSrcToDst, acks, sh, doExecuteAck)
+	if err != nil {
+		return nil, err
+	}
 
-	// For ack relay, no timeout execution is needed
+	// For ack relay, no timeout execution is needed.
+	// updateClients must be called after all proofs are generated, but the resulting msgs must precede them in the tx
+	var msgs []sdk.Msg
 	if m, err := st.UpdateClients(ctx, src, dst, isSrcToDst, doExecuteRelay, doExecuteAck, false, sh, doRefresh); err != nil {
 		return nil, err
 	} else {
 		msgs = append(msgs, m...)
 	}
-
-	if m, err := st.RelayAcknowledgements(ctx, src, dst, isSrcToDst, acks, sh, doExecuteAck); err != nil {
-		return nil, err
-	} else {
-		msgs = append(msgs, m...)
-	}
+	msgs = append(msgs, ackMsgs...)
 	return msgs, nil
 }
 

--- a/core/channel-upgrade.go
+++ b/core/channel-upgrade.go
@@ -228,12 +228,6 @@ func CancelChannelUpgrade(ctx context.Context, chain, cp *ProvableChain, settlem
 			return false, nil
 		}
 
-		cpHeaders, err := SetupHeadersForUpdateSync(cp, ctx, chain, sh.GetLatestFinalizedHeader(cp.ChainID()))
-		if err != nil {
-			logger.ErrorContext(ctx, "failed to set up headers for LC update", err)
-			return false, err
-		}
-
 		upgErr, err := QueryChannelUpgradeError(cpQueryCtx, cp)
 		if err != nil {
 			logger.ErrorContext(ctx, "failed to query the channel upgrade error receipt", err)
@@ -255,6 +249,12 @@ func CancelChannelUpgrade(ctx context.Context, chain, cp *ProvableChain, settlem
 			// the cancellation will be successful.
 			upgErr = &chantypes.QueryUpgradeErrorResponse{}
 		} else if err = ProveChannelUpgradeError(cpQueryCtx, cp, upgErr); err != nil {
+			return false, err
+		}
+
+		cpHeaders, err := SetupHeadersForUpdateSync(cp, ctx, chain, sh.GetLatestFinalizedHeader(cp.ChainID()))
+		if err != nil {
+			logger.ErrorContext(ctx, "failed to set up headers for LC update", err)
 			return false, err
 		}
 
@@ -557,16 +557,6 @@ func upgradeChannelStep(ctx context.Context, src, dst *ProvableChain, targetSrcS
 
 				addr := mustGetAddress(src)
 
-				dstUpdateHeaders, err := sh.SetupHeadersForUpdate(ctx, dst, src)
-				if err != nil {
-					logger.ErrorContext(ctx, "failed to set up headers for LC update on dst chain", err)
-					return err
-				}
-
-				if len(dstUpdateHeaders) > 0 {
-					out.Src = append(out.Src, src.Path().UpdateClients(dstUpdateHeaders, addr)...)
-				}
-
 				msg, err := buildActionMsg(
 					src,
 					srcAction,
@@ -582,6 +572,16 @@ func upgradeChannelStep(ctx context.Context, src, dst *ProvableChain, targetSrcS
 					return err
 				}
 
+				dstUpdateHeaders, err := sh.SetupHeadersForUpdate(ctx, dst, src)
+				if err != nil {
+					logger.ErrorContext(ctx, "failed to set up headers for LC update on dst chain", err)
+					return err
+				}
+
+				if len(dstUpdateHeaders) > 0 {
+					out.Src = append(out.Src, src.Path().UpdateClients(dstUpdateHeaders, addr)...)
+				}
+
 				out.Src = append(out.Src, msg)
 				return nil
 			})
@@ -590,16 +590,6 @@ func upgradeChannelStep(ctx context.Context, src, dst *ProvableChain, targetSrcS
 		if dstAction != UPGRADE_ACTION_NONE {
 			eg.Go(func() error {
 				addr := mustGetAddress(dst)
-
-				srcUpdateHeaders, err := sh.SetupHeadersForUpdate(ctx, src, dst)
-				if err != nil {
-					logger.ErrorContext(ctx, "failed to set up headers for LC update on src chain", err)
-					return err
-				}
-
-				if len(srcUpdateHeaders) > 0 {
-					out.Dst = append(out.Dst, dst.Path().UpdateClients(srcUpdateHeaders, addr)...)
-				}
 
 				msg, err := buildActionMsg(
 					dst,
@@ -614,6 +604,16 @@ func upgradeChannelStep(ctx context.Context, src, dst *ProvableChain, targetSrcS
 				if err != nil {
 					logger.ErrorContext(ctx, "failed to build Msg for the dst chain", err)
 					return err
+				}
+
+				srcUpdateHeaders, err := sh.SetupHeadersForUpdate(ctx, src, dst)
+				if err != nil {
+					logger.ErrorContext(ctx, "failed to set up headers for LC update on src chain", err)
+					return err
+				}
+
+				if len(srcUpdateHeaders) > 0 {
+					out.Dst = append(out.Dst, dst.Path().UpdateClients(srcUpdateHeaders, addr)...)
 				}
 
 				out.Dst = append(out.Dst, msg)

--- a/core/channel.go
+++ b/core/channel.go
@@ -150,17 +150,17 @@ func resolveCreateChannelFutureProofs(
 	queryCtx := sh.GetQueryContext(ctx, from.ChainID())
 	var err error
 
-	fromProofs.updateHeaders, err = sh.SetupHeadersForUpdate(ctx, from, to)
-	if err != nil {
-		logger.ErrorContext(ctx, "error setting up headers for update", err)
-		return err
-	}
-
 	if fromProofs.chanRes != nil && fromProofs.chanRes.Channel.State != chantypes.UNINITIALIZED {
 		err = ProveChannel(queryCtx, from, fromProofs.chanRes)
 		if err != nil {
 			return err
 		}
+	}
+
+	fromProofs.updateHeaders, err = sh.SetupHeadersForUpdate(ctx, from, to)
+	if err != nil {
+		logger.ErrorContext(ctx, "error setting up headers for update", err)
+		return err
 	}
 	return nil
 }

--- a/core/connection.go
+++ b/core/connection.go
@@ -160,12 +160,6 @@ func resolveCreateConnectionFutureProofs(
 	queryCtx := sh.GetQueryContext(ctx, fromChain.ChainID())
 	var err error
 
-	fromProofs.updateHeaders, err = sh.SetupHeadersForUpdate(ctx, fromChain, toChain)
-	if err != nil {
-		logger.ErrorContext(ctx, "error setting up headers for update", err)
-		return err
-	}
-
 	if fromProofs.connRes != nil && fromProofs.connRes.Connection.State != conntypes.UNINITIALIZED {
 		err = ProveConnection(queryCtx, fromChain, fromProofs.connRes)
 		if err != nil {
@@ -192,6 +186,12 @@ func resolveCreateConnectionFutureProofs(
 		if err != nil {
 			return err
 		}
+	}
+
+	fromProofs.updateHeaders, err = sh.SetupHeadersForUpdate(ctx, fromChain, toChain)
+	if err != nil {
+		logger.ErrorContext(ctx, "error setting up headers for update", err)
+		return err
 	}
 
 	return nil

--- a/core/service.go
+++ b/core/service.go
@@ -117,8 +117,25 @@ func (srv *RelayService) relayMsgs(ctx context.Context, isSrcToDst bool, packets
 		logger = GetChannelPairLoggerRelative(srv.dst, srv.src)
 	}
 
-	var msgs []sdk.Msg
+	// relay packets if unrelayed seqs exist
+	packetMsgs, err := srv.st.RelayPackets(ctx, srv.src, srv.dst, isSrcToDst, packets, sh, doExecuteRelay)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to relay packets", err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	// relay acks if unrelayed seqs exist
+	ackMsgs, err := srv.st.RelayAcknowledgements(ctx, srv.src, srv.dst, isSrcToDst, acks, sh, doExecuteAck)
+	if err != nil {
+		logger.ErrorContext(ctx, "failed to relay acknowledgements", err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
 	// update clients
+	// NOTE: this must be called after all proofs are generated, but the resulting msgs must precede them in the tx
+	var msgs []sdk.Msg
 	if m, err := srv.st.UpdateClients(ctx, srv.src, srv.dst, isSrcToDst, doExecuteRelay, doExecuteAck, doExecuteTimeout, sh, doRefresh); err != nil {
 		logger.ErrorContext(ctx, "failed to update clients", err)
 		span.SetStatus(codes.Error, err.Error())
@@ -126,24 +143,8 @@ func (srv *RelayService) relayMsgs(ctx context.Context, isSrcToDst bool, packets
 	} else {
 		msgs = append(msgs, m...)
 	}
-
-	// relay packets if unrelayed seqs exist
-	if m, err := srv.st.RelayPackets(ctx, srv.src, srv.dst, isSrcToDst, packets, sh, doExecuteRelay); err != nil {
-		logger.ErrorContext(ctx, "failed to relay packets", err)
-		span.SetStatus(codes.Error, err.Error())
-		return nil, err
-	} else {
-		msgs = append(msgs, m...)
-	}
-
-	// relay acks if unrelayed seqs exist
-	if m, err := srv.st.RelayAcknowledgements(ctx, srv.src, srv.dst, isSrcToDst, acks, sh, doExecuteAck); err != nil {
-		logger.ErrorContext(ctx, "failed to relay acknowledgements", err)
-		span.SetStatus(codes.Error, err.Error())
-		return nil, err
-	} else {
-		msgs = append(msgs, m...)
-	}
+	msgs = append(msgs, packetMsgs...)
+	msgs = append(msgs, ackMsgs...)
 
 	return msgs, nil
 }
@@ -198,19 +199,20 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 		// - MsgTimeout for pseqs.DstTimeout (dst's packets that timed out, sent back to dst)
 		eg.Go(func() error {
 			isSrcToDst := true
+			// Collect timeout messages for dst's packets (DstTimeout → dst chain)
+			var timeoutMsgs []sdk.Msg
+			if doExecuteTimeoutDst {
+				var err error
+				timeoutMsgs, err = srv.st.RelayTimeoutPackets(ctx, srv.dst, srv.src, pseqs.DstTimeout, srv.sh, true)
+				if err != nil {
+					return err
+				}
+			}
 			m, err := srv.relayMsgs(ctx, isSrcToDst, pseqs.Src, aseqs.Src, srv.sh, doExecuteRelayDst, doExecuteAckDst, doExecuteTimeoutDst, true)
 			if err != nil {
 				return err
 			}
-			// Add timeout messages for dst's packets (DstTimeout → dst chain)
-			if doExecuteTimeoutDst {
-				timeoutMsgs, err := srv.st.RelayTimeoutPackets(ctx, srv.dst, srv.src, pseqs.DstTimeout, srv.sh, true)
-				if err != nil {
-					return err
-				}
-				m = append(m, timeoutMsgs...)
-			}
-			msgs.Dst = m
+			msgs.Dst = append(m, timeoutMsgs...)
 			return nil
 		})
 
@@ -219,19 +221,20 @@ func (srv *RelayService) Serve(ctx context.Context) error {
 		// - MsgTimeout for pseqs.SrcTimeout (src's packets that timed out, sent back to src)
 		eg.Go(func() error {
 			isSrcToDst := false
+			// Collect timeout messages for src's packets (SrcTimeout → src chain)
+			var timeoutMsgs []sdk.Msg
+			if doExecuteTimeoutSrc {
+				var err error
+				timeoutMsgs, err = srv.st.RelayTimeoutPackets(ctx, srv.src, srv.dst, pseqs.SrcTimeout, srv.sh, true)
+				if err != nil {
+					return err
+				}
+			}
 			m, err := srv.relayMsgs(ctx, isSrcToDst, pseqs.Dst, aseqs.Dst, srv.sh, doExecuteRelaySrc, doExecuteAckSrc, doExecuteTimeoutSrc, true)
 			if err != nil {
 				return err
 			}
-			// Add timeout messages for src's packets (SrcTimeout → src chain)
-			if doExecuteTimeoutSrc {
-				timeoutMsgs, err := srv.st.RelayTimeoutPackets(ctx, srv.src, srv.dst, pseqs.SrcTimeout, srv.sh, true)
-				if err != nil {
-					return err
-				}
-				m = append(m, timeoutMsgs...)
-			}
-			msgs.Src = m
+			msgs.Src = append(m, timeoutMsgs...)
 			return nil
 		})
 


### PR DESCRIPTION
## Summary

Flip the call order of the two `Prover` operations so that `ProveState` (proof generation) runs **before** `SetupHeadersForUpdate` (update-client header preparation) in every flow:

- **Relay flow**: `RelayService.relayMsgs` / `Serve` (`core/service.go`) and the `tx relay` / `tx relay-acknowledgements` commands (`cmd/tx.go`) now generate packet/ack/timeout proofs first and set up update headers last.
- **Connection/channel handshake**: `resolveCreateConnectionFutureProofs` (`core/connection.go`) and `resolveCreateChannelFutureProofs` (`core/channel.go`) prove the handshake state first.
- **Channel upgrade**: `upgradeChannelStep` builds the action msg (with its proofs) before setting up headers, and `CancelChannelUpgrade` proves the upgrade error receipt before `SetupHeadersForUpdateSync` (`core/channel-upgrade.go`).

Only the call order changes: the message order in the built tx is unchanged — `MsgUpdateClient` still precedes the messages that carry the proofs.

## Testing

- `make test` (unit tests) passes
- tm2tm E2E suite passes (client/connection/channel handshakes, channel upgrade incl. cancel scenarios, `tx relay`, `service start` with relay/ack/timeout paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)